### PR TITLE
fix: gates generation

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -46,8 +46,8 @@ impl Display for AGateType {
     }
 }
 
-impl From<ExpressionInfixOpcode> for AGateType {
-    fn from(opcode: ExpressionInfixOpcode) -> Self {
+impl From<&ExpressionInfixOpcode> for AGateType {
+    fn from(opcode: &ExpressionInfixOpcode) -> Self {
         match opcode {
             ExpressionInfixOpcode::Add => AGateType::AAdd,
             ExpressionInfixOpcode::Div => AGateType::ADiv,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -3,6 +3,7 @@
 //! This module defines structures and operations for arithmetic circuits, including variables, gates, and circuit composition.
 
 use crate::compiler::ParseError;
+use circom_program_structure::ast::ExpressionInfixOpcode;
 use mpz_circuits::GateType;
 use regex::Captures;
 use serde::{Deserialize, Serialize};
@@ -14,17 +15,17 @@ use std::{
 /// Types of gates that can be used in an arithmetic circuit.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AGateType {
-    ANone,
     AAdd,
-    ASub,
-    AMul,
     ADiv,
     AEq,
-    ANeq,
-    ALEq,
     AGEq,
-    ALt,
     AGt,
+    ALEq,
+    ALt,
+    AMul,
+    ANeq,
+    ANone,
+    ASub,
 }
 
 impl Display for AGateType {
@@ -41,6 +42,24 @@ impl Display for AGateType {
             AGateType::AGEq => write!(f, "AGEq"),
             AGateType::ALt => write!(f, "ALt"),
             AGateType::AGt => write!(f, "AGt"),
+        }
+    }
+}
+
+impl From<ExpressionInfixOpcode> for AGateType {
+    fn from(opcode: ExpressionInfixOpcode) -> Self {
+        match opcode {
+            ExpressionInfixOpcode::Add => AGateType::AAdd,
+            ExpressionInfixOpcode::Div => AGateType::ADiv,
+            ExpressionInfixOpcode::Eq => AGateType::AEq,
+            ExpressionInfixOpcode::Greater => AGateType::AGt,
+            ExpressionInfixOpcode::GreaterEq => AGateType::AGEq,
+            ExpressionInfixOpcode::Lesser => AGateType::ALt,
+            ExpressionInfixOpcode::LesserEq => AGateType::ALEq,
+            ExpressionInfixOpcode::Mul => AGateType::AMul,
+            ExpressionInfixOpcode::NotEq => AGateType::ANeq,
+            ExpressionInfixOpcode::Sub => AGateType::ASub,
+            _ => AGateType::ANone,
         }
     }
 }
@@ -167,7 +186,7 @@ impl ArithmeticCircuit {
 
     pub fn add_gate(
         &mut self,
-        output_name: &String,
+        output_name: &str,
         output_id: u32,
         lhs_id: u32,
         rhs_id: u32,
@@ -195,20 +214,6 @@ impl ArithmeticCircuit {
         );
         self.gates.insert(self.gate_count, node);
     }
-
-    // pub fn add_gate(
-    //     &mut self,
-    //     output: &ArithmeticVar,
-    //     lhs: &ArithmeticVar,
-    //     rhs: &ArithmeticVar,
-    //     gate_type: AGateType) {
-
-    //     self.gate_count += 1;
-    //     let node = ArithmeticNode::new(self.gate_count, gate_type, lhs.var_id, rhs.var_id, output.var_id);
-
-    //     self.gates.insert(self.gate_count, node);
-
-    // }
 
     pub fn replace_input_var_in_gate(&mut self, var_id: u32, new_var_id: u32) {
         for i in 1..(self.gate_count + 1) {
@@ -302,7 +307,7 @@ impl ArithmeticCircuit {
         let deserialized: ArithmeticCircuit = serde_json::from_str(&serialized).unwrap();
 
         // Prints deserialized = Point { x: 1, y: 2 }
-        println!("deserialized = {:?}", deserialized);
+        println!("deserialized = {:#?}", deserialized);
     }
 }
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -44,7 +44,7 @@ pub fn execute_statement(
             dimensions,
             ..
         } => {
-            println!("Declaration of {}", name);
+            debug!("Declaration of {}", name);
             match xtype {
                 // VariableType::AnonymousComponent => {
                 //     execute_anonymous_component_declaration(
@@ -167,7 +167,7 @@ pub fn execute_statement(
         While { cond, stmt, .. } => loop {
             let var = String::from("while");
             let (res, rb) = execute_expression(ac, runtime, &var, cond, program_archive);
-            println!("[Execute] res = {} {}", res, rb);
+            debug!("res = {} {}", res, rb);
             execute_statement(ac, runtime, stmt, program_archive);
             if res.contains("0") {
                 break;
@@ -176,7 +176,7 @@ pub fn execute_statement(
             // let var = String::from("while");
             // ac.add_var(&var, SignalType::Intermediate);
             // let lhs = traverse_expression(ac, runtime, &var, cond, program_archive);
-            // println!("While cond {}", lhs);
+            // debug!("While cond {}", lhs);
             // traverse_statement(ac, stmt, program_archive);
         },
         ConstraintEquality { meta, lhe, rhe, .. } => {
@@ -243,28 +243,28 @@ pub fn execute_statement(
             ..
         } => {
             let mut name_access = String::from(var);
-            println!("[Execute] Variable found {}", var.to_string());
+            debug!("Variable found {}", var.to_string());
             for a in access.iter() {
                 match a {
                     Access::ArrayAccess(expr) => {
-                        println!("[Execute] Array access found");
+                        debug!("Array access found");
                         // let mut dim_u32_vec = Vec::new();
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
                         // dim_u32_vec.push(dim_u32_str.parse::<u32>().unwrap());
                         name_access.push_str("_");
                         name_access.push_str(dim_u32_str.as_str());
-                        println!("[Execute] Change var name to {}", name_access);
+                        debug!("Change var name to {}", name_access);
                     }
                     Access::ComponentAccess(name) => {
-                        println!("Component access not handled");
+                        debug!("Component access not handled");
                     }
                 }
             }
             let (rhs, rhsb) = execute_expression(ac, runtime, &name_access, rhe, program_archive);
-            println!("[Execute] Assigning {} ? {} to {}", rhs, rhsb, &name_access);
+            debug!("Assigning {} ? {} to {}", rhs, rhsb, &name_access);
             if rhsb {
-                println!("[Execute] Assigning {} to {}", rhs, &name_access);
+                debug!("Assigning {} to {}", rhs, &name_access);
                 // TODO: revisit this
                 // Check if the signal already has this value assigned. If it doesn't, assign it.
                 let ctx = runtime.get_current_context().unwrap();
@@ -273,10 +273,7 @@ pub fn execute_statement(
 
                 if res.is_ok() {
                     if expected == res.unwrap().get_u32().unwrap() {
-                        println!(
-                            "[Execute] Signal {} already has value {}",
-                            &name_access, expected
-                        );
+                        debug!("Signal {} already has value {}", &name_access, expected);
                     } else {
                         ctx.clear_data_item(&name_access).unwrap();
                     }
@@ -291,7 +288,7 @@ pub fn execute_statement(
         }
         LogCall { args, .. } => {}
         UnderscoreSubstitution { meta, rhe, op } => {
-            println!("UnderscoreSubstitution found");
+            debug!("UnderscoreSubstitution found");
         }
         _ => {
             unimplemented!()
@@ -333,15 +330,15 @@ pub fn execute_expression(
             let ctx = runtime.get_current_context().unwrap();
             //TODO: for generic handling we should generate a name for an intermediate expression, we could ideally use only the values returned
             let varlhs = ctx.declare_auto_var().unwrap();
-            println!("[Execute] Auto var for lhs {}", varlhs);
+            debug!("Auto var for lhs {}", varlhs);
             let varrhs = ctx.declare_auto_var().unwrap();
-            println!("[Execute] Auto var for rhs {}", varrhs);
+            debug!("Auto var for rhs {}", varrhs);
             let (varlop, lhsb) = execute_expression(ac, runtime, &varlhs, lhe, program_archive);
-            println!("[Execute] lhs {} {}", varlop, lhsb);
+            debug!("lhs {} {}", varlop, lhsb);
             let (varrop, rhsb) = execute_expression(ac, runtime, &varrhs, rhe, program_archive);
-            println!("[Execute] rhs {} {}", varrop, rhsb);
+            debug!("rhs {} {}", varrop, rhsb);
             let (res, rb) = execute_infix_op(ac, runtime, var, &varlop, &varrop, *infix_op);
-            println!("[Execute] infix out res {}", res);
+            debug!("infix out res {}", res);
             (res.to_string(), rb)
         }
         PrefixOp {
@@ -349,7 +346,7 @@ pub fn execute_expression(
             prefix_op,
             rhe,
         } => {
-            println!("Prefix found ");
+            debug!("Prefix found ");
             (var.to_string(), false)
         }
         InlineSwitchOp {
@@ -361,16 +358,16 @@ pub fn execute_expression(
         ParallelOp { meta, rhe } => todo!(),
         Variable { meta, name, access } => {
             let mut name_access = String::from(name);
-            debug!("[Execute] Variable found {}", name.to_string());
+            debug!("Variable found {}", name.to_string());
             for a in access.iter() {
                 match a {
                     Access::ArrayAccess(expr) => {
-                        debug!("[Execute] Array access found");
+                        debug!("Array access found");
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
                         name_access.push_str("_");
                         name_access.push_str(dim_u32_str.as_str());
-                        debug!("[Execute] Changed var name to {}", name_access);
+                        debug!("Changed var name to {}", name_access);
                     }
                     Access::ComponentAccess(name) => {
                         debug!("Component access found");
@@ -380,7 +377,7 @@ pub fn execute_expression(
             (name_access.to_string(), false)
         }
         Call { meta, id, args } => {
-            println!("Call found {}", id.to_string());
+            debug!("Call found {}", id.to_string());
             // find the template and execute it
             (id.to_string(), false)
         }
@@ -393,7 +390,7 @@ pub fn execute_expression(
             names,
         } => todo!(),
         ArrayInLine { meta, values } => {
-            println!("ArrayInLine found");
+            debug!("ArrayInLine found");
             (var.to_string(), false)
         }
         Tuple { meta, values } => todo!(),
@@ -402,153 +399,96 @@ pub fn execute_expression(
             value,
             dimension,
         } => {
-            println!("UniformArray found");
+            debug!("UniformArray found");
             (var.to_string(), false)
         }
     }
 }
 
-//WIP HERE
-// TODO: named_access should support multi-dimension, right now 1
-
 /// Executes an infix operation, performing the specified arithmetic or logical computation.
 pub fn execute_infix_op(
     ac: &mut ArithmeticCircuit,
     runtime: &mut Runtime,
-    output: &String,
-    input_lhs: &String,
-    input_rhs: &String,
+    output: &str,
+    input_lhs: &str,
+    input_rhs: &str,
     infixop: ExpressionInfixOpcode,
 ) -> (u32, bool) {
+    debug!("Executing infix op");
     let ctx = runtime.get_current_context().unwrap();
 
-    let mut can_execute_infix = true;
-    if ctx.get_data_item(input_lhs).is_err() {
-        println!("[Execute] cannot get lhs var val {}", input_lhs);
-        can_execute_infix = false;
-    }
-    if ctx.get_data_item(input_rhs).is_err() {
-        println!("[Execute] cannot get rhs var val {}", input_rhs);
-        can_execute_infix = false;
-    }
-    println!("[Execute] can execute infix {}", can_execute_infix);
+    // Check availability of lhs and rhs values
+    let lhsvar_res = ctx.get_data_item(input_lhs);
+    let rhsvar_res = ctx.get_data_item(input_rhs);
 
-    if !can_execute_infix {
+    if lhsvar_res.is_err() || rhsvar_res.is_err() {
+        debug!(
+            "Error getting variables: lhs={}, rhs={}",
+            input_lhs, input_rhs
+        );
         ctx.clear_data_item(output).unwrap();
-        println!("[Execute] Now mark {} as no value", output);
         return (0, false);
     }
 
-    let lhsvar_val = ctx.get_data_item(input_lhs).unwrap().get_u32().unwrap();
-    println!("[Execute] infix lhs = {}", lhsvar_val);
-    let rhsvar_val = ctx.get_data_item(input_rhs).unwrap().get_u32().unwrap();
-    println!("[Execute] infix lhs = {}", rhsvar_val);
-    let declare_res = ctx.declare_signal(output);
+    // Extract values
+    let lhsvar_val = lhsvar_res.unwrap().get_u32().unwrap();
+    let rhsvar_val = rhsvar_res.unwrap().get_u32().unwrap();
 
-    if declare_res.is_ok() {
-        declare_res.unwrap();
-    }
+    // ctx.declare_signal(output).unwrap();
+    let gate_type = AGateType::from(infixop);
+    debug!("{} = {} {} {}", output, input_lhs, gate_type, input_rhs);
 
-    // let var = ac.add_var(var_id, &output);
-    // let lvar = ac.get_var(lhsvar_id);
-    // let rvar = ac.get_var(rhsvar_id);
-
-    let mut res = 0;
-
-    use ExpressionInfixOpcode::*;
-    let mut gate_type = AGateType::AAdd;
-    match infixop {
-        Mul => {
-            println!(
-                "[Execute] Mul op {} = {} * {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            gate_type = AGateType::AMul;
-            res = lhsvar_val * rhsvar_val;
+    let res = match gate_type {
+        AGateType::AAdd => lhsvar_val + rhsvar_val,
+        AGateType::ADiv => lhsvar_val / rhsvar_val,
+        AGateType::AEq => {
+            if lhsvar_val == rhsvar_val {
+                1
+            } else {
+                0
+            }
         }
-        Div => {
-            println!(
-                "[Execute] Div op {} = {} / {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            gate_type = AGateType::ADiv;
-            res = lhsvar_val / rhsvar_val;
+        AGateType::AGEq => {
+            if lhsvar_val >= rhsvar_val {
+                1
+            } else {
+                0
+            }
         }
-        Add => {
-            println!(
-                "[Execute] Add op {} = {} + {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            gate_type = AGateType::AAdd;
-            res = lhsvar_val + rhsvar_val;
+        AGateType::AGt => {
+            if lhsvar_val > rhsvar_val {
+                1
+            } else {
+                0
+            }
         }
-        Sub => {
-            println!(
-                "[Execute] Sub op {} = {} - {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            gate_type = AGateType::ASub;
-            res = lhsvar_val - rhsvar_val;
+        AGateType::ALEq => {
+            if lhsvar_val <= rhsvar_val {
+                1
+            } else {
+                0
+            }
         }
-        // Pow => {},
-        // IntDiv => {},
-        // Mod => {},
-        // ShiftL => {},
-        // ShiftR => {},
-        LesserEq => {
-            println!(
-                "[Execute] LesserEq op {} = {} <= {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            res = if lhsvar_val <= rhsvar_val { 1 } else { 0 };
+        AGateType::ALt => {
+            if lhsvar_val < rhsvar_val {
+                1
+            } else {
+                0
+            }
         }
-        GreaterEq => {
-            println!(
-                "[Execute] GreaterEq op {} = {} >= {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            res = if lhsvar_val >= rhsvar_val { 1 } else { 0 };
+        AGateType::AMul => lhsvar_val * rhsvar_val,
+        AGateType::ANeq => {
+            if lhsvar_val != rhsvar_val {
+                1
+            } else {
+                0
+            }
         }
-        Lesser => {
-            println!(
-                "[Execute] Lesser op {} = {} < {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            res = if lhsvar_val < rhsvar_val { 1 } else { 0 };
-        }
-        Greater => {
-            println!(
-                "[Execute] Greater op {} = {} > {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            res = if lhsvar_val > rhsvar_val { 1 } else { 0 };
-        }
-        Eq => {
-            println!(
-                "[Execute] Eq op {} = {} == {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            gate_type = AGateType::AEq;
-            res = if lhsvar_val == rhsvar_val { 1 } else { 0 };
-        }
-        NotEq => {
-            println!(
-                "[Execute] Neq op {} = {} != {}",
-                output, lhsvar_val, rhsvar_val
-            );
-            gate_type = AGateType::ANeq;
-            res = if lhsvar_val != rhsvar_val { 1 } else { 0 };
-        }
-        // BoolOr => {},
-        // BoolAnd => {},
-        // BitOr => {},
-        // BitAnd => {},
-        // BitXor => {},
-        _ => {
-            unreachable!()
-        }
+        AGateType::ANone => todo!(),
+        AGateType::ASub => lhsvar_val - rhsvar_val,
     };
-    println!("[Execute] infix res = {}", res);
+
+    debug!("Infix res = {}", res);
+
     (res, true)
-    // ac.add_gate(&output, var_id, lhsvar_id, rhsvar_id, gate_type);
 }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -430,10 +430,11 @@ pub fn traverse_infix_op(
     let lhsvar_res = ctx.get_data_item(input_lhs);
     let rhsvar_res = ctx.get_data_item(input_rhs);
 
+    // TODO: HERE IS WHERE INFIX OP CREATE GATES BUT BECAUSE WE CAN GET VALUES FROM lhs and rhs IT WILL EXECUTE INSTEAD
     // Skip traversal if can execute
-    if lhsvar_res.is_ok() && rhsvar_res.is_ok() {
-        return execute_infix_op(ac, runtime, output, input_lhs, input_rhs, infixop);
-    }
+    // if lhsvar_res.is_ok() && rhsvar_res.is_ok() {
+    //     return execute_infix_op(ac, runtime, output, input_lhs, input_rhs, infixop);
+    // }
 
     // Unreachable code
 

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -5,7 +5,7 @@
 //! It's main purpose is to traverse signals.
 
 use crate::circuit::{AGateType, ArithmeticCircuit};
-use crate::execute::{execute_expression, execute_infix_op, execute_statement};
+use crate::execute::{execute_expression, execute_statement};
 use crate::runtime::{DataContent, Runtime};
 use circom_circom_algebra::num_traits::ToPrimitive;
 use circom_program_structure::ast::{
@@ -331,7 +331,7 @@ pub fn traverse_expression(
             debug!("lhs {}", varlop);
             let varrop = traverse_expression(ac, runtime, &varrhs, rhe, program_archive);
             debug!("rhs {}", varlop);
-            let (res, ret) = traverse_infix_op(ac, runtime, var, &varlop, &varrop, *infix_op);
+            let (res, ret) = traverse_infix_op(ac, runtime, var, &varlop, &varrop, infix_op);
             if ret {
                 return res.to_string();
             }
@@ -342,7 +342,7 @@ pub fn traverse_expression(
             prefix_op,
             rhe,
         } => {
-            debug!("Prefix found ");
+            debug!("Prefix found");
             var.to_string()
         }
         InlineSwitchOp {
@@ -421,7 +421,7 @@ pub fn traverse_infix_op(
     output: &str,
     input_lhs: &str,
     input_rhs: &str,
-    infixop: ExpressionInfixOpcode,
+    infixop: &ExpressionInfixOpcode,
 ) -> (u32, bool) {
     debug!("Traversing infix op");
     let ctx = runtime.get_current_context().unwrap();
@@ -435,9 +435,6 @@ pub fn traverse_infix_op(
     // if lhsvar_res.is_ok() && rhsvar_res.is_ok() {
     //     return execute_infix_op(ac, runtime, output, input_lhs, input_rhs, infixop);
     // }
-
-    // Unreachable code
-
     // debug!("Can't get variables: lhs={}, rhs={}", input_lhs, input_rhs);
     // let _ = ctx.clear_data_item(output).unwrap();
 


### PR DESCRIPTION
# Description

This PR fixes the `traverse_infix_op` function to enable adding the gates to the `ArithmeticCircuit` instance. It bypasses a check to see if the variables were declared and execute the operation instead of creating corresponding gate.

It also includes some small code restructuring updates.