### PR TITLE
restructure: code cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: Main Action
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Clippy
+        run: cargo clippy --verbose
+      - name: Tests
+        run: cargo test --verbose

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -3,6 +3,7 @@
 //! This module defines structures and operations for arithmetic circuits, including variables, gates, and circuit composition.
 
 use circom_program_structure::ast::ExpressionInfixOpcode;
+use log::debug;
 use mpz_circuits::{BuilderError, GateType};
 use regex::Captures;
 use serde::{Deserialize, Serialize};
@@ -150,10 +151,7 @@ impl ArithmeticCircuit {
     }
 
     pub fn add_var(&mut self, var_id: u32, var_name: &str) -> &ArithmeticVar {
-        println!(
-            "[ArithmeticCircuit] Add var {} with id {}",
-            var_name, var_id
-        );
+        debug!("Add var {} with id {}", var_name, var_id);
 
         // Not sure if var_count is needed
         self.var_count += 1;
@@ -164,10 +162,7 @@ impl ArithmeticCircuit {
     }
 
     pub fn add_const_var(&mut self, var_id: u32, var_val: u32) -> &ArithmeticVar {
-        println!(
-            "[ArithmeticCircuit] var {} now has value {}",
-            var_id, var_val
-        );
+        debug!("var {} now has value {}", var_id, var_val);
 
         // Not sure if var_count is needed
         self.var_count += 1;
@@ -187,7 +182,7 @@ impl ArithmeticCircuit {
         self.vars.get_mut(&var_id).unwrap()
     }
 
-    //We support ADD, MUL, CADD, CMUL, DIV, CDIV, CINVERT, IFTHENELSE, FOR
+    // We support ADD, MUL, CADD, CMUL, DIV, CDIV, CINVERT, IFTHENELSE, FOR
 
     pub fn add_gate(
         &mut self,
@@ -203,8 +198,8 @@ impl ArithmeticCircuit {
         let var_output = self.get_var(output_id);
         let var_lhs = self.get_var(lhs_id);
         let var_rhs = self.get_var(rhs_id);
-        println!(
-            "[ArithmeticCircuit] Gate added id {}: ({}, {}, {}) = ({}, {}, {}) {} ({}, {}, {})",
+        debug!(
+            "Gate added id {}: ({}, {}, {}) = ({}, {}, {}) {} ({}, {}, {})",
             node.gate_id,
             node.output_id,
             var_output.is_const,
@@ -272,18 +267,17 @@ impl ArithmeticCircuit {
     }
 
     pub fn print_ac(&self) {
-        println!("[ArithmeticCircuit] Whole Arithmetic Circuit");
+        println!("Whole Arithmetic Circuit");
         for i in 1..(self.gate_count + 1) {
             if !self.gates.contains_key(&i) {
                 continue;
             }
             let node = self.gates.get(&(i)).unwrap();
-            // println!("[ArithmeticCircuit] Gate {}: {} = {} [{}] {}", i, anv.output_id, anv.input_lhs_id, anv.gate_type.to_string(), anv.input_rhs_id);
             let var_output = self.get_var(node.output_id);
             let var_lhs = self.get_var(node.input_lhs_id);
             let var_rhs = self.get_var(node.input_rhs_id);
             println!(
-                "[ArithmeticCircuit] Gate id {}: ({}, {}, {}) = ({}, {}, {}) {} ({}, {}, {})",
+                "Gate id {}: ({}, {}, {}) = ({}, {}, {}) {} ({}, {}, {})",
                 node.gate_id,
                 node.output_id,
                 var_output.is_const,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -126,6 +126,12 @@ pub struct ArithmeticCircuit {
     pub gates: HashMap<u32, ArithmeticNode>,
 }
 
+impl Default for ArithmeticCircuit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ArithmeticCircuit {
     pub fn new() -> ArithmeticCircuit {
         ArithmeticCircuit {
@@ -207,7 +213,7 @@ impl ArithmeticCircuit {
             node.input_lhs_id,
             var_lhs.is_const,
             var_lhs.const_value,
-            node.gate_type.to_string(),
+            node.gate_type,
             node.input_rhs_id,
             var_rhs.is_const,
             var_rhs.const_value
@@ -286,7 +292,7 @@ impl ArithmeticCircuit {
                 node.input_lhs_id,
                 var_lhs.is_const,
                 var_lhs.const_value,
-                node.gate_type.to_string(),
+                node.gate_type,
                 node.input_rhs_id,
                 var_rhs.is_const,
                 var_rhs.const_value

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2,9 +2,8 @@
 //!
 //! This module defines structures and operations for arithmetic circuits, including variables, gates, and circuit composition.
 
-use crate::compiler::ParseError;
 use circom_program_structure::ast::ExpressionInfixOpcode;
-use mpz_circuits::GateType;
+use mpz_circuits::{BuilderError, GateType};
 use regex::Captures;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -351,4 +350,18 @@ impl UncheckedGate {
             gate_type,
         })
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("uninitialized feed: {0}")]
+    UninitializedFeed(usize),
+    #[error("unsupported gate type: {0}")]
+    UnsupportedGateType(String),
+    #[error(transparent)]
+    BuilderError(#[from] BuilderError),
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -311,6 +311,7 @@ impl ArithmeticCircuit {
     }
 }
 
+#[allow(dead_code)]
 /// Represents a gate in its raw, unchecked form, used during parsing.
 struct UncheckedGate {
     xref: usize,
@@ -320,7 +321,8 @@ struct UncheckedGate {
 }
 
 impl UncheckedGate {
-    fn parse(captures: Captures) -> Result<Self, ParseError> {
+    #[allow(dead_code)]
+    pub fn parse(captures: Captures) -> Result<Self, ParseError> {
         let xref: usize = captures.name("xref").unwrap().as_str().parse()?;
         let yref: Option<usize> = captures
             .name("yref")

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -14,7 +14,7 @@ use std::env::current_dir;
 use std::path::Path;
 use std::path::PathBuf;
 
-const VERSION: &'static str = "2.0.0";
+const VERSION: &str = "2.0.0";
 
 #[allow(missing_docs)]
 pub struct CompilerConfig {
@@ -130,14 +130,14 @@ pub struct Input {
     pub link_libraries: Vec<PathBuf>,
 }
 
-const R1CS: &'static str = "r1cs";
-const WAT: &'static str = "wat";
-const WASM: &'static str = "wasm";
-const CPP: &'static str = "cpp";
-const JS: &'static str = "js";
-const DAT: &'static str = "dat";
-const SYM: &'static str = "sym";
-const JSON: &'static str = "json";
+const R1CS: &str = "r1cs";
+const WAT: &str = "wat";
+const WASM: &str = "wasm";
+const CPP: &str = "cpp";
+const JS: &str = "js";
+const DAT: &str = "dat";
+const SYM: &str = "sym";
+const JSON: &str = "json";
 
 impl Input {
     pub fn default() -> Result<Input, ()> {
@@ -251,7 +251,7 @@ impl Input {
     }
 
     pub fn input_file(&self) -> &str {
-        &self.input_program.to_str().unwrap()
+        self.input_program.to_str().unwrap()
     }
     pub fn r1cs_file(&self) -> &str {
         self.out_r1cs.to_str().unwrap()

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -376,6 +376,7 @@ pub enum SimplificationStyle {
     O1,
     O2(usize),
 }
+
 pub fn get_simplification_style(matches: &ArgMatches) -> Result<SimplificationStyle, ()> {
     let o_0 = matches.is_present("no_simplification");
     let o_1 = matches.is_present("reduced_simplification");

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -5,7 +5,6 @@
 
 use circom_compiler::compiler_interface;
 use circom_compiler::compiler_interface::{Config, VCP};
-use circom_constraint_writers::debug_writer::DebugWriter;
 use circom_program_structure::error_definition::Report;
 use circom_program_structure::program_archive::ProgramArchive;
 use circom_type_analysis::check_types::check_types;
@@ -43,7 +42,7 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
     // config.wasm_flag = false;
     // config.wat_flag = false;
 
-    let circuit = compiler_interface::run_compiler(
+    compiler_interface::run_compiler(
         config.vcp,
         Config {
             debug_output: config.debug_output,
@@ -52,37 +51,6 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
         },
         VERSION,
     )?;
-
-    // Sample code for calling writer
-
-    // if config.c_flag {
-    //     compiler_interface::write_c(
-    //         &circuit,
-    //         &config.c_folder,
-    //         &config.c_run_name,
-    //         &config.c_file,
-    //         &config.dat_file,
-    //     )?;
-    //     println!(
-    //         "{} {} and {}",
-    //         Colour::Green.paint("Written successfully:"),
-    //         config.c_file,
-    //         config.dat_file
-    //     );
-    //     println!(
-    //         "{} {}/{}, {}, {}, {}, {}, {}, {} and {}",
-    //         Colour::Green.paint("Written successfully:"),
-    //         &config.c_folder,
-    //         "main.cpp".to_string(),
-    //         "circom.hpp".to_string(),
-    //         "calcwit.hpp".to_string(),
-    //         "calcwit.cpp".to_string(),
-    //         "fr.hpp".to_string(),
-    //         "fr.cpp".to_string(),
-    //         "fr.asm".to_string(),
-    //         "Makefile".to_string()
-    //     );
-    // }
 
     Ok(())
 }
@@ -110,7 +78,7 @@ pub fn execute_project(
     config: ExecutionConfig,
 ) -> Result<VCP, ()> {
     use circom_constraint_generation::{build_circuit, BuildConfig};
-    let debug = DebugWriter::new(config.json_constraints).unwrap();
+
     let build_config = BuildConfig {
         no_rounds: config.no_rounds,
         flag_json_sub: config.json_substitution_flag,
@@ -122,74 +90,11 @@ pub fn execute_project(
         flag_old_heuristics: config.flag_old_heuristics,
         prime: config.prime,
     };
-    let custom_gates = program_archive.custom_gates;
-    let (exporter, vcp) = build_circuit(program_archive, build_config)?;
 
-    // Sample code for generate constraints but we don't need it now
-    // Maybe later for generate for Garbler and Evaluator
-
-    // if config.r1cs_flag {
-    //     generate_output_r1cs(&config.r1cs, exporter.as_ref(), custom_gates)?;
-    // }
-    // if config.sym_flag {
-    //     generate_output_sym(&config.sym, exporter.as_ref())?;
-    // }
-    // if config.json_constraint_flag {
-    //     generate_json_constraints(&debug, exporter.as_ref())?;
-    // }
+    let (_, vcp) = build_circuit(program_archive, build_config)?;
 
     Result::Ok(vcp)
 }
-
-// fn generate_output_r1cs(
-//     file: &str,
-//     exporter: &dyn ConstraintExporter,
-//     custom_gates: bool,
-// ) -> Result<(), ()> {
-//     if let Result::Ok(()) = exporter.r1cs(file, custom_gates) {
-//         println!("{} {}", Colour::Green.paint("Written successfully:"), file);
-//         Result::Ok(())
-//     } else {
-//         eprintln!(
-//             "{}",
-//             Colour::Red.paint("Could not write the output in the given path")
-//         );
-//         Result::Err(())
-//     }
-// }
-
-// fn generate_output_sym(file: &str, exporter: &dyn ConstraintExporter) -> Result<(), ()> {
-//     if let Result::Ok(()) = exporter.sym(file) {
-//         println!("{} {}", Colour::Green.paint("Written successfully:"), file);
-//         Result::Ok(())
-//     } else {
-//         eprintln!(
-//             "{}",
-//             Colour::Red.paint("Could not write the output in the given path")
-//         );
-//         Result::Err(())
-//     }
-// }
-
-// fn generate_json_constraints(
-//     debug: &DebugWriter,
-//     exporter: &dyn ConstraintExporter,
-// ) -> Result<(), ()> {
-//     if let Ok(()) = exporter.json_constraints(&debug) {
-//         println!(
-//             "{} {}",
-//             Colour::Green.paint("Constraints written in:"),
-//             debug.json_constraints
-//         );
-//         Result::Ok(())
-//     } else {
-//         eprintln!(
-//             "{}",
-//             Colour::Red.paint("Could not write the output in the given path")
-//         );
-//         Result::Err(())
-//     }
-// }
 
 pub struct Input {
     pub input_program: PathBuf,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -66,7 +66,7 @@ pub fn execute_statement(
             let (res, rb) = execute_expression(ac, runtime, &var, cond, program_archive);
             debug!("res = {} {}", res, rb);
             execute_statement(ac, runtime, stmt, program_archive);
-            if res.contains("0") {
+            if res.contains('0') {
                 break;
             }
         },
@@ -81,7 +81,7 @@ pub fn execute_statement(
                         debug!("Array access found");
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
-                        name_access.push_str("_");
+                        name_access.push('_');
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Change var name to {}", name_access);
                     }
@@ -177,7 +177,7 @@ pub fn execute_expression(
                         debug!("Array access found");
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
-                        name_access.push_str("_");
+                        name_access.push('_');
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Changed var name to {}", name_access);
                     }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -37,7 +37,6 @@ pub fn execute_statement(
             ..
         } => {
             debug!("Declaration of {}", name);
-
             // Process index in case of array
             let dim_u32_vec: Vec<u32> = dimensions
                 .iter()
@@ -58,7 +57,7 @@ pub fn execute_statement(
                 VariableType::Signal(signal_type, _tag_list) => {
                     traverse_signal_declaration(ac, runtime, name, *signal_type, &dim_u32_vec)
                 }
-                VariableType::AnonymousComponent => unimplemented!(),
+                _ => unimplemented!(),
             }
         }
         Statement::While { cond, stmt, .. } => loop {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -31,7 +31,6 @@ pub fn execute_statement(
             }
         }
         Statement::Declaration {
-            meta,
             xtype,
             name,
             dimensions,
@@ -72,12 +71,7 @@ pub fn execute_statement(
             }
         },
         Statement::Substitution {
-            meta,
-            var,
-            access,
-            op,
-            rhe,
-            ..
+            var, access, rhe, ..
         } => {
             let mut name_access = String::from(var);
             debug!("Variable found {}", var.to_string());
@@ -91,8 +85,8 @@ pub fn execute_statement(
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Change var name to {}", name_access);
                     }
-                    Access::ComponentAccess(name) => {
-                        debug!("Component access not handled");
+                    Access::ComponentAccess(_) => {
+                        todo!("Component access not handled");
                     }
                 }
             }
@@ -137,7 +131,6 @@ pub fn execute_expression(
     expr: &Expression,
     program_archive: &ProgramArchive,
 ) -> (String, bool) {
-    use Expression::*;
     match expr {
         Expression::Number(_, value) => {
             // Declaring a constant.
@@ -155,10 +148,7 @@ pub fn execute_expression(
             (val.to_string(), true)
         }
         Expression::InfixOp {
-            meta,
-            lhe,
-            infix_op,
-            rhe,
+            lhe, infix_op, rhe, ..
         } => {
             let ctx = runtime.get_current_context().unwrap();
             //TODO: for generic handling we should generate a name for an intermediate expression, we could ideally use only the values returned
@@ -174,16 +164,11 @@ pub fn execute_expression(
             debug!("infix out res {}", res);
             (res.to_string(), rb)
         }
-        Expression::PrefixOp {
-            meta,
-            prefix_op,
-            rhe,
-        } => {
+        Expression::PrefixOp { .. } => {
             debug!("Prefix found ");
             (var.to_string(), false)
         }
-        Expression::ParallelOp { meta, rhe } => todo!(),
-        Expression::Variable { meta, name, access } => {
+        Expression::Variable { name, access, .. } => {
             let mut name_access = String::from(name);
             debug!("Variable found {}", name.to_string());
             for a in access.iter() {
@@ -196,27 +181,23 @@ pub fn execute_expression(
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Changed var name to {}", name_access);
                     }
-                    Access::ComponentAccess(name) => {
-                        debug!("Component access found");
+                    Access::ComponentAccess(_) => {
+                        todo!("Component access found");
                     }
                 }
             }
             (name_access.to_string(), false)
         }
-        Expression::Call { meta, id, args } => {
+        Expression::Call { id, .. } => {
             debug!("Call found {}", id.to_string());
             // find the template and execute it
             (id.to_string(), false)
         }
-        ArrayInLine { meta, values } => {
+        Expression::ArrayInLine { .. } => {
             debug!("ArrayInLine found");
             (var.to_string(), false)
         }
-        UniformArray {
-            meta,
-            value,
-            dimension,
-        } => {
+        Expression::UniformArray { .. } => {
             debug!("UniformArray found");
             (var.to_string(), false)
         }
@@ -226,7 +207,7 @@ pub fn execute_expression(
 
 /// Executes an infix operation, performing the specified arithmetic or logical computation.
 pub fn execute_infix_op(
-    ac: &mut ArithmeticCircuit,
+    _ac: &mut ArithmeticCircuit,
     runtime: &mut Runtime,
     output: &str,
     input_lhs: &str,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -139,8 +139,6 @@ pub fn execute_expression(
 
             let res = runtime.get_current_context().unwrap().declare_const(val);
             if res.is_ok() {
-                res.unwrap();
-
                 // Setting as id the constant value
                 ac.add_const_var(val, val);
             }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -19,25 +19,18 @@ use log::debug;
 pub fn execute_statement(
     ac: &mut ArithmeticCircuit,
     runtime: &mut Runtime,
-    stmt: &Statement,
+    statement: &Statement,
     program_archive: &ProgramArchive,
 ) {
-    use Statement::*;
-    let id = stmt.get_meta().elem_id;
-
-    // Analysis::reached(&mut runtime.analysis, id);
-
-    // let mut can_be_simplified = true;
-
-    match stmt {
-        InitializationBlock {
+    match statement {
+        Statement::InitializationBlock {
             initializations, ..
         } => {
-            for istmt in initializations.iter() {
-                execute_statement(ac, runtime, istmt, program_archive);
+            for stmt in initializations {
+                execute_statement(ac, runtime, stmt, program_archive);
             }
         }
-        Declaration {
+        Statement::Declaration {
             meta,
             xtype,
             name,
@@ -45,126 +38,31 @@ pub fn execute_statement(
             ..
         } => {
             debug!("Declaration of {}", name);
+
+            // Process index in case of array
+            let dim_u32_vec: Vec<u32> = dimensions
+                .iter()
+                .map(|dimension| {
+                    let dim_u32_str =
+                        traverse_expression(ac, runtime, name, dimension, program_archive);
+                    dim_u32_str
+                        .parse::<u32>()
+                        .expect("Failed to parse dimension as u32")
+                })
+                .collect();
+
             match xtype {
-                // VariableType::AnonymousComponent => {
-                //     execute_anonymous_component_declaration(
-                //         name,
-                //         meta.clone(),
-                //         &dimensions,
-                //         &mut runtime.environment,
-                //         &mut runtime.anonymous_components,
-                //     );
-                // }
-                _ => {
-                    // Process index in case of array
-                    let mut dim_u32_vec = Vec::new();
-                    for dimension in dimensions.iter() {
-                        let dim_u32_str =
-                            traverse_expression(ac, runtime, name, dimension, program_archive);
-                        dim_u32_vec.push(dim_u32_str.parse::<u32>().unwrap());
-                    }
-                    // treat_result_with_memory_error_void(
-                    //     valid_array_declaration(&arithmetic_values),
-                    //     meta,
-                    //     &mut runtime.runtime_errors,
-                    //     &runtime.call_trace,
-                    // )?;
-                    // let usable_dimensions =
-                    //     if let Option::Some(dimensions) = cast_indexing(&arithmetic_values) {
-                    //         dimensions
-                    //     } else {
-                    //         let err = Result::Err(ExecutionError::ArraySizeTooBig);
-                    //         treat_result_with_execution_error(
-                    //             err,
-                    //             meta,
-                    //             &mut runtime.runtime_errors,
-                    //             &runtime.call_trace,
-                    //         )?
-                    //     };
-                    match xtype {
-                        VariableType::Component => traverse_component_declaration(
-                            ac,
-                            runtime,
-                            name,
-                            &dim_u32_vec, // &usable_dimensions
-                                          // &mut runtime.environment,
-                                          // actual_node
-                        ),
-                        VariableType::Var => traverse_variable_declaration(
-                            ac,
-                            runtime,
-                            name,
-                            &dim_u32_vec, // &usable_dimensions
-                        ),
-                        VariableType::Signal(signal_type, tag_list) => traverse_signal_declaration(
-                            ac,
-                            runtime,
-                            name,
-                            *signal_type,
-                            &dim_u32_vec, // &usable_dimensions
-                        ),
-                        _ => {
-                            unreachable!()
-                        }
-                    }
+                VariableType::Component => {
+                    traverse_component_declaration(ac, runtime, name, &dim_u32_vec)
                 }
+                VariableType::Var => traverse_variable_declaration(ac, runtime, name, &dim_u32_vec),
+                VariableType::Signal(signal_type, _tag_list) => {
+                    traverse_signal_declaration(ac, runtime, name, *signal_type, &dim_u32_vec)
+                }
+                VariableType::AnonymousComponent => unimplemented!(),
             }
-            // Option::None
         }
-        IfThenElse {
-            cond,
-            if_case,
-            else_case,
-            ..
-        } => {
-            // let var = String::from("IFTHENELSE");
-            // ac.add_var(&var, SignalType::Intermediate);
-            // let lhs = traverse_expression(ac, &var, cond, program_archive);
-            // traverse_statement(ac, &if_case, program_archive);
-            // let else_case = else_case.as_ref().map(|e| e.as_ref());
-            // traverse_statement(ac, else_case.unwrap(), program_archive);
-            //     let else_case = else_case.as_ref().map(|e| e.as_ref());
-            //     let (possible_return, can_simplify, _) = execute_conditional_statement(
-            //         cond,
-            //         if_case,
-            //         else_case,
-            //         program_archive,
-            //         runtime,
-            //         actual_node,
-            //         flags
-            //     )?;
-            //     can_be_simplified = can_simplify;
-            //     possible_return
-            // }
-            // While { cond, stmt, .. } => loop {
-            //     let (returned, can_simplify, condition_result) = execute_conditional_statement(
-            //         cond,
-            //         stmt,
-            //         Option::None,
-            //         program_archive,
-            //         runtime,
-            //         actual_node,
-            //         flags
-            //     )?;
-            //     can_be_simplified &= can_simplify;
-            //     if returned.is_some() {
-            //         break returned;
-            //     } else if condition_result.is_none() {
-            //         let (returned, _, _) = execute_conditional_statement(
-            //             cond,
-            //             stmt,
-            //             None,
-            //             program_archive,
-            //             runtime,
-            //             actual_node,
-            //             flags
-            //         )?;
-            //         break returned;
-            //     } else if !condition_result.unwrap() {
-            //         break returned;
-            //     }
-        }
-        While { cond, stmt, .. } => loop {
+        Statement::While { cond, stmt, .. } => loop {
             let var = String::from("while");
             let (res, rb) = execute_expression(ac, runtime, &var, cond, program_archive);
             debug!("res = {} {}", res, rb);
@@ -172,69 +70,8 @@ pub fn execute_statement(
             if res.contains("0") {
                 break;
             }
-            // traverse_expression(ac, runtime, var, cond, program_archive);
-            // let var = String::from("while");
-            // ac.add_var(&var, SignalType::Intermediate);
-            // let lhs = traverse_expression(ac, runtime, &var, cond, program_archive);
-            // debug!("While cond {}", lhs);
-            // traverse_statement(ac, stmt, program_archive);
         },
-        ConstraintEquality { meta, lhe, rhe, .. } => {
-            // debug_assert!(actual_node.is_some());
-            // let f_left = execute_expression(lhe, program_archive, runtime, flags)?;
-            // let f_right = execute_expression(rhe, program_archive, runtime, flags)?;
-            // let arith_left = safe_unwrap_to_arithmetic_slice(f_left, line!());
-            // let arith_right = safe_unwrap_to_arithmetic_slice(f_right, line!());
-
-            // let correct_dims_result = AExpressionSlice::check_correct_dims(&arith_left, &Vec::new(), &arith_right, true);
-            // treat_result_with_memory_error_void(
-            //     correct_dims_result,
-            //     meta,
-            //     &mut runtime.runtime_errors,
-            //     &runtime.call_trace,
-            // )?;
-            // for i in 0..AExpressionSlice::get_number_of_cells(&arith_left){
-            //     let value_left = treat_result_with_memory_error(
-            //         AExpressionSlice::access_value_by_index(&arith_left, i),
-            //         meta,
-            //         &mut runtime.runtime_errors,
-            //         &runtime.call_trace,
-            //     )?;
-            //     let value_right = treat_result_with_memory_error(
-            //         AExpressionSlice::access_value_by_index(&arith_right, i),
-            //         meta,
-            //         &mut runtime.runtime_errors,
-            //         &runtime.call_trace,
-            //     )?;
-            //     let possible_non_quadratic =
-            //         AExpr::sub(
-            //             &value_left,
-            //             &value_right,
-            //             &runtime.constants.get_p()
-            //         );
-            //     if possible_non_quadratic.is_nonquadratic() {
-            //         treat_result_with_execution_error(
-            //             Result::Err(ExecutionError::NonQuadraticConstraint),
-            //             meta,
-            //             &mut runtime.runtime_errors,
-            //             &runtime.call_trace,
-            //         )?;
-            //     }
-            //     let quadratic_expression = possible_non_quadratic;
-            //     let constraint_expression = AExpr::transform_expression_to_constraint_form(
-            //         quadratic_expression,
-            //         runtime.constants.get_p(),
-            //     )
-            //     .unwrap();
-            //     if let Option::Some(node) = actual_node {
-            //         node.add_constraint(constraint_expression);
-            //     }
-            // }
-            // Option::None
-        }
-        Return { value, .. } => {}
-        Assert { arg, meta, .. } => {}
-        Substitution {
+        Statement::Substitution {
             meta,
             var,
             access,
@@ -248,10 +85,8 @@ pub fn execute_statement(
                 match a {
                     Access::ArrayAccess(expr) => {
                         debug!("Array access found");
-                        // let mut dim_u32_vec = Vec::new();
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
-                        // dim_u32_vec.push(dim_u32_str.parse::<u32>().unwrap());
                         name_access.push_str("_");
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Change var name to {}", name_access);
@@ -285,12 +120,8 @@ pub fn execute_statement(
                 }
             }
         }
-        Block { stmts, .. } => {
+        Statement::Block { stmts, .. } => {
             traverse_sequence_of_statements(ac, runtime, stmts, program_archive, true);
-        }
-        LogCall { args, .. } => {}
-        UnderscoreSubstitution { meta, rhe, op } => {
-            debug!("UnderscoreSubstitution found");
         }
         _ => {
             unimplemented!()
@@ -307,9 +138,8 @@ pub fn execute_expression(
     program_archive: &ProgramArchive,
 ) -> (String, bool) {
     use Expression::*;
-    // let mut can_be_simplified = true;
     match expr {
-        Number(_, value) => {
+        Expression::Number(_, value) => {
             // Declaring a constant.
             let val = value.to_u32().unwrap();
             debug!("Number value {}", val);
@@ -317,17 +147,18 @@ pub fn execute_expression(
             let res = runtime.get_current_context().unwrap().declare_const(val);
             if res.is_ok() {
                 res.unwrap();
-                ac.add_const_var(val, val); // Setting as id the constant value
+
+                // Setting as id the constant value
+                ac.add_const_var(val, val);
             }
 
             (val.to_string(), true)
         }
-        InfixOp {
+        Expression::InfixOp {
             meta,
             lhe,
             infix_op,
             rhe,
-            ..
         } => {
             let ctx = runtime.get_current_context().unwrap();
             //TODO: for generic handling we should generate a name for an intermediate expression, we could ideally use only the values returned
@@ -343,7 +174,7 @@ pub fn execute_expression(
             debug!("infix out res {}", res);
             (res.to_string(), rb)
         }
-        PrefixOp {
+        Expression::PrefixOp {
             meta,
             prefix_op,
             rhe,
@@ -351,14 +182,8 @@ pub fn execute_expression(
             debug!("Prefix found ");
             (var.to_string(), false)
         }
-        InlineSwitchOp {
-            meta,
-            cond,
-            if_true,
-            if_false,
-        } => todo!(),
-        ParallelOp { meta, rhe } => todo!(),
-        Variable { meta, name, access } => {
+        Expression::ParallelOp { meta, rhe } => todo!(),
+        Expression::Variable { meta, name, access } => {
             let mut name_access = String::from(name);
             debug!("Variable found {}", name.to_string());
             for a in access.iter() {
@@ -378,24 +203,15 @@ pub fn execute_expression(
             }
             (name_access.to_string(), false)
         }
-        Call { meta, id, args } => {
+        Expression::Call { meta, id, args } => {
             debug!("Call found {}", id.to_string());
             // find the template and execute it
             (id.to_string(), false)
         }
-        AnonymousComp {
-            meta,
-            id,
-            is_parallel,
-            params,
-            signals,
-            names,
-        } => todo!(),
         ArrayInLine { meta, values } => {
             debug!("ArrayInLine found");
             (var.to_string(), false)
         }
-        Tuple { meta, values } => todo!(),
         UniformArray {
             meta,
             value,
@@ -404,6 +220,7 @@ pub fn execute_expression(
             debug!("UniformArray found");
             (var.to_string(), false)
         }
+        _ => unimplemented!(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! This library provides the functionality to convert a Circom program into an arithmetic circuit.
 
-#![allow(unused_variables, dead_code, unused_assignments)]
-
 pub mod circuit;
 pub mod compiler;
 pub mod execute;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,10 @@ fn main() {
     dotenv().ok();
     init_from_env(Env::default().filter_or("LOG_LEVEL", "info"));
 
-    let _circ = parse_circom(
+    parse_circom(
         "circuits/bristol/adder64_reverse.txt",
         &[ValueType::U64, ValueType::U64],
         &[ValueType::U64],
     )
-    .unwrap();
-
-    // stupid assert always true
-    assert_eq!(3, 3);
-
-    //let output: u64 = evaluate!(circ, fn(1u64, 2u64) -> u64).unwrap();
-
-    //assert_eq!(output, 3);
+    .unwrap()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,10 @@
 use circom_2_arithc::program::parse_circom;
 use dotenv::dotenv;
 use env_logger::{init_from_env, Env};
-use mpz_circuits::types::ValueType;
 
 fn main() {
     dotenv().ok();
     init_from_env(Env::default().filter_or("LOG_LEVEL", "info"));
 
-    parse_circom(
-        "circuits/bristol/adder64_reverse.txt",
-        &[ValueType::U64, ValueType::U64],
-        &[ValueType::U64],
-    )
-    .unwrap()
+    parse_circom().unwrap()
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -8,10 +8,9 @@ use crate::runtime::Runtime;
 use crate::traverse::traverse_sequence_of_statements;
 use circom_program_structure::ast::Expression;
 use circom_program_structure::program_archive::ProgramArchive;
-use mpz_circuits::types::ValueType;
 
 /// Parses a Circom file, processes its content, and sets up the necessary structures for circuit analysis.
-pub fn parse_circom(filename: &str, inputs: &[ValueType], outputs: &[ValueType]) -> Result<(), ()> {
+pub fn parse_circom() -> Result<(), ()> {
     let user_input = Input::default()?;
     let mut program_archive = parse_project(&user_input)?;
     analyse_project(&mut program_archive)?;
@@ -28,11 +27,10 @@ pub fn parse_circom(filename: &str, inputs: &[ValueType], outputs: &[ValueType])
 
 /// Traverses the program structure of a parsed Circom file and constructs an arithmetic circuit.
 pub fn traverse_program(program_archive: &ProgramArchive) -> ArithmeticCircuit {
-    let main_file_id = program_archive.get_file_id_main();
     let mut ac = ArithmeticCircuit::new();
     let mut runtime = Runtime::new().unwrap();
 
-    if let Expression::Call { id, args, .. } = program_archive.get_main_expression() {
+    if let Expression::Call { id, .. } = program_archive.get_main_expression() {
         let template_body = program_archive.get_template_data(id).get_body_as_vec();
 
         traverse_sequence_of_statements(

--- a/src/program.rs
+++ b/src/program.rs
@@ -10,10 +10,10 @@ use circom_program_structure::ast::Expression;
 use circom_program_structure::program_archive::ProgramArchive;
 
 /// Parses a Circom file, processes its content, and sets up the necessary structures for circuit analysis.
-pub fn parse_circom() -> Result<(), ()> {
-    let user_input = Input::default()?;
-    let mut program_archive = parse_project(&user_input)?;
-    analyse_project(&mut program_archive)?;
+pub fn parse_circom() -> Result<(), &'static str> {
+    let user_input = Input::default();
+    let mut program_archive = parse_project(&user_input).map_err(|_| "Parsing failed")?;
+    analyse_project(&mut program_archive).map_err(|_| "Analysis failed")?;
 
     let mut circuit = traverse_program(&program_archive);
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -16,145 +16,23 @@ pub fn parse_circom(filename: &str, inputs: &[ValueType], outputs: &[ValueType])
     let mut program_archive = parse_project(&user_input)?;
     analyse_project(&mut program_archive)?;
 
-    // let config = ExecutionConfig {
-    //     no_rounds: user_input.no_rounds(),
-    //     flag_p: user_input.parallel_simplification_flag(),
-    //     flag_s: user_input.reduced_simplification_flag(),
-    //     flag_f: user_input.unsimplified_flag(),
-    //     flag_old_heuristics: user_input.flag_old_heuristics(),
-    //     flag_verbose: user_input.flag_verbose(),
-    //     inspect_constraints_flag: user_input.inspect_constraints_flag(),
-    //     r1cs_flag: user_input.r1cs_flag(),
-    //     json_constraint_flag: user_input.json_constraints_flag(),
-    //     json_substitution_flag: user_input.json_substitutions_flag(),
-    //     sym_flag: user_input.sym_flag(),
-    //     sym: user_input.sym_file().to_string(),
-    //     r1cs: user_input.r1cs_file().to_string(),
-    //     json_constraints: user_input.json_constraints_file().to_string(),
-    //     prime: user_input.prime(),
-    // };
+    let mut circuit = traverse_program(&program_archive);
 
-    traverse_program(&program_archive);
-
-    // let circuit = execute_project(program_archive, config)?;
-    // let compilation_config = CompilerConfig {
-    //     vcp: circuit,
-    //     debug_output: user_input.print_ir_flag(),
-    //     c_flag: user_input.c_flag(),
-    //     wasm_flag: user_input.wasm_flag(),
-    //     wat_flag: user_input.wat_flag(),
-    //     js_folder: user_input.js_folder().to_string(),
-    //     wasm_name: user_input.wasm_name().to_string(),
-    //     c_folder: user_input.c_folder().to_string(),
-    //     c_run_name: user_input.c_run_name().to_string(),
-    //     c_file: user_input.c_file().to_string(),
-    //     dat_file: user_input.dat_file().to_string(),
-    //     wat_file: user_input.wat_file().to_string(),
-    //     wasm_file: user_input.wasm_file().to_string(),
-    //     produce_input_log: user_input.main_inputs_flag(),
-    // };
-    // compile(compilation_config)?;
-
-    // Sample code for binary circuit
-
-    // let builder = CircuitBuilder::new();
-
-    // let mut feed_ids: Vec<usize> = Vec::new();
-    // let mut feed_map: HashMap<usize, Node<Feed>> = HashMap::default();
-
-    // let mut input_len = 0;
-    // for input in inputs {
-    //     let input = builder.add_input_by_type(input.clone());
-    //     for (node, old_id) in input.iter().zip(input_len..input_len + input.len()) {
-    //         feed_map.insert(old_id, *node);
-    //     }
-    //     input_len += input.len();
-    // }
-
-    // let mut state = builder.state().borrow_mut();
-    // let pattern = Regex::new(GATE_PATTERN).unwrap();
-    // for cap in pattern.captures_iter(&file) {
-    //     let UncheckedGate {
-    //         xref,
-    //         yref,
-    //         zref,
-    //         gate_type,
-    //     } = UncheckedGate::parse(cap)?;
-    //     feed_ids.push(zref);
-
-    //     match gate_type {
-    //         GateType::Xor => {
-    //             let new_x = feed_map
-    //                 .get(&xref)
-    //                 .ok_or(ParseError::UninitializedFeed(xref))?;
-    //             let new_y = feed_map
-    //                 .get(&yref.unwrap())
-    //                 .ok_or(ParseError::UninitializedFeed(yref.unwrap()))?;
-    //             let new_z = state.add_xor_gate(*new_x, *new_y);
-    //             feed_map.insert(zref, new_z);
-    //         }
-    //         GateType::And => {
-    //             let new_x = feed_map
-    //                 .get(&xref)
-    //                 .ok_or(ParseError::UninitializedFeed(xref))?;
-    //             let new_y = feed_map
-    //                 .get(&yref.unwrap())
-    //                 .ok_or(ParseError::UninitializedFeed(yref.unwrap()))?;
-    //             let new_z = state.add_and_gate(*new_x, *new_y);
-    //             feed_map.insert(zref, new_z);
-    //         }
-    //         GateType::Inv => {
-    //             let new_x = feed_map
-    //                 .get(&xref)
-    //                 .ok_or(ParseError::UninitializedFeed(xref))?;
-    //             let new_z = state.add_inv_gate(*new_x);
-    //             feed_map.insert(zref, new_z);
-    //         }
-    //     }
-    // }
-    // drop(state);
-    // feed_ids.sort();
-
-    // for output in outputs.iter().rev() {
-    //     let feeds = feed_ids
-    //         .drain(feed_ids.len() - output.len()..)
-    //         .map(|id| {
-    //             *feed_map
-    //                 .get(&id)
-    //                 .expect("Old feed should be mapped to new feed")
-    //         })
-    //         .collect::<Vec<Node<Feed>>>();
-
-    //     let output = output.to_bin_repr(&feeds).unwrap();
-    //     builder.add_output(output);
-    // }
-
-    // Ok(builder.build()?)
+    circuit.print_ac();
+    circuit.truncate_zero_add_gate();
+    circuit.print_ac();
+    circuit.serde();
 
     Ok(())
 }
 
 /// Traverses the program structure of a parsed Circom file and constructs an arithmetic circuit.
 pub fn traverse_program(program_archive: &ProgramArchive) -> ArithmeticCircuit {
+    let main_file_id = program_archive.get_file_id_main();
     let mut ac = ArithmeticCircuit::new();
-
     let mut runtime = Runtime::new().unwrap();
 
-    let main_file_id = program_archive.get_file_id_main();
-
-    // let mut runtime_information = RuntimeInformation::new(*main_file_id, program_archive.id_max, prime);
-
-    use Expression::Call;
-
-    // runtime_information.public_inputs = program_archive.get_public_inputs_main_component().clone();
-
-    // Main expresssion
-    // program_archive.get_main_expression()
-
-    // Public inputs
-    // program_archive.get_public_inputs_main_component().clone();
-
-    if let Call { id, args, .. } = program_archive.get_main_expression() {
+    if let Expression::Call { id, args, .. } = program_archive.get_main_expression() {
         let template_body = program_archive.get_template_data(id).get_body_as_vec();
 
         traverse_sequence_of_statements(
@@ -164,39 +42,6 @@ pub fn traverse_program(program_archive: &ProgramArchive) -> ArithmeticCircuit {
             program_archive,
             true,
         );
-
-        ac.print_ac();
-        ac.truncate_zero_add_gate();
-        ac.print_ac();
-        ac.serde();
-
-        // let folded_value_result =
-        //     if let Call { id, args, .. } = &program_archive.get_main_expression() {
-        //         let mut arg_values = Vec::new();
-        //         for arg_expression in args.iter() {
-        //             let f_arg = execute_expression(arg_expression, program_archive, &mut runtime_information, flags);
-        //             arg_values.push(safe_unwrap_to_arithmetic_slice(f_arg.unwrap(), line!()));
-        //             // improve
-        //         }
-        //         execute_template_call_complete(
-        //             id,
-        //             arg_values,
-        //             BTreeMap::new(),
-        //             program_archive,
-        //             &mut runtime_information,
-        //             flags,
-        //         )
-        //     } else {
-        //         unreachable!("The main expression should be a call.");
-        //     };
-
-        // match folded_value_result {
-        //     Result::Err(_) => Result::Err(runtime_information.runtime_errors),
-        //     Result::Ok(folded_value) => {
-        //         debug_assert!(FoldedValue::valid_node_pointer(&folded_value));
-        //         Result::Ok((runtime_information.exec_program, runtime_information.runtime_errors))
-        //     }
-        // }
     };
 
     ac

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -92,6 +92,7 @@ impl Runtime {
 #[derive(Clone)]
 pub struct Context {
     id: u32,
+    #[allow(dead_code)]
     caller_id: u32,
     values: HashMap<String, DataItem>, // Name -> Value
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -232,12 +232,12 @@ impl Context {
     pub fn declare_signal_array(
         &mut self,
         name: &str,
-        indice: Vec<u32>,
+        indices: Vec<u32>,
     ) -> Result<(String, u32), RuntimeError> {
         let mut signal_name = name.to_string();
 
-        for i in 0..indice.len() {
-            signal_name.push_str(&format!("_{}", indice[i]));
+        for indice in indices {
+            signal_name.push_str(&format!("_{}", indice));
         }
 
         let signal_id = self.declare_signal(&signal_name)?;
@@ -327,11 +327,7 @@ impl DataItem {
 
     /// Checks if the content of the data item is an array.
     pub fn is_array(&self) -> bool {
-        if let Some(DataContent::Array(_)) = self.content {
-            true
-        } else {
-            false
-        }
+        matches!(self.content, Some(DataContent::Array(_)))
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,7 +15,7 @@ pub enum ContextOrigin {
     Block,
 }
 
-/// Runtime - manages the scope stack and variable tracking.
+/// Runtime - manages the context stack and variable tracking.
 pub struct Runtime {
     ctx_stack: Vec<Context>,
     current_ctx: u32,

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -120,7 +120,7 @@ pub fn traverse_expression(
     runtime: &mut Runtime,
     var: &String,
     expression: &Expression,
-    program_archive: &ProgramArchive,
+    _program_archive: &ProgramArchive,
 ) -> String {
     match expression {
         Expression::Number(_, value) => {
@@ -130,7 +130,6 @@ pub fn traverse_expression(
 
             let res = runtime.get_current_context().unwrap().declare_const(val);
             if res.is_ok() {
-                res.unwrap();
                 ac.add_const_var(val, val); // Setting as id the constant value
             }
 
@@ -145,9 +144,9 @@ pub fn traverse_expression(
             debug!("Auto var for lhs {}", varlhs);
             let varrhs = ctx.declare_auto_var().unwrap();
             debug!("Auto var for rhs {}", varrhs);
-            let varlop = traverse_expression(ac, runtime, &varlhs, lhe, program_archive);
+            let varlop = traverse_expression(ac, runtime, &varlhs, lhe, _program_archive);
             debug!("lhs {}", varlop);
-            let varrop = traverse_expression(ac, runtime, &varrhs, rhe, program_archive);
+            let varrop = traverse_expression(ac, runtime, &varrhs, rhe, _program_archive);
             debug!("rhs {}", varlop);
             let (res, ret) = traverse_infix_op(ac, runtime, var, &varlop, &varrop, infix_op);
             if ret {
@@ -167,7 +166,7 @@ pub fn traverse_expression(
                     Access::ArrayAccess(expr) => {
                         debug!("Array access found");
                         let dim_u32_str =
-                            traverse_expression(ac, runtime, var, expr, program_archive);
+                            traverse_expression(ac, runtime, var, expr, _program_archive);
                         name_access.push('_');
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Changed var name to {}", name_access);
@@ -252,7 +251,7 @@ pub fn traverse_component_declaration(
     _ac: &mut ArithmeticCircuit,
     _runtime: &mut Runtime,
     _comp_name: &str,
-    _dim_u32_vec: &Vec<u32>,
+    _dim_u32_vec: &[u32],
 ) {
     todo!()
 }
@@ -283,9 +282,7 @@ pub fn traverse_variable_declaration(
     } else {
         let dim_u32 = *dim_u32_vec.last().unwrap();
         for i in 0..dim_u32 {
-            let (name, id) = ctx
-                .declare_signal_array(var_name, vec![i])
-                .unwrap();
+            let (name, id) = ctx.declare_signal_array(var_name, vec![i]).unwrap();
             ac.add_var(id, &name);
         }
     }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -25,9 +25,7 @@ pub fn traverse_sequence_of_statements(
     for stmt in stmts.iter() {
         traverse_statement(ac, runtime, stmt, program_archive);
     }
-    if is_complete_template {
-        //execute_delayed_declarations(program_archive, runtime, actual_node, flags)?;
-    }
+    // TODO: handle complete template
 }
 
 /// Analyzes a single statement, delegating to specialized functions based on the statement's nature.
@@ -37,22 +35,15 @@ pub fn traverse_statement(
     stmt: &Statement,
     program_archive: &ProgramArchive,
 ) {
-    use Statement::*;
-    let id = stmt.get_meta().elem_id;
-
-    // Analysis::reached(&mut runtime.analysis, id);
-
-    // let mut can_be_simplified = true;
-
     match stmt {
-        InitializationBlock {
+        Statement::InitializationBlock {
             initializations, ..
         } => {
-            for istmt in initializations.iter() {
-                traverse_statement(ac, runtime, istmt, program_archive);
+            for statement in initializations {
+                traverse_statement(ac, runtime, statement, program_archive);
             }
         }
-        Declaration {
+        Statement::Declaration {
             meta,
             xtype,
             name,
@@ -60,125 +51,31 @@ pub fn traverse_statement(
             ..
         } => {
             debug!("Declaration of {}", name);
+
+            // Process index in case of array
+            let dim_u32_vec: Vec<u32> = dimensions
+                .iter()
+                .map(|dimension| {
+                    let dim_u32_str =
+                        traverse_expression(ac, runtime, name, dimension, program_archive);
+                    dim_u32_str
+                        .parse::<u32>()
+                        .expect("Failed to parse dimension")
+                })
+                .collect();
+
             match xtype {
-                // VariableType::AnonymousComponent => {
-                //     execute_anonymous_component_declaration(
-                //         name,
-                //         meta.clone(),
-                //         &dimensions,
-                //         &mut runtime.environment,
-                //         &mut runtime.anonymous_components,
-                //     );
-                // }
-                _ => {
-                    let mut dim_u32_vec = Vec::new();
-                    for dimension in dimensions.iter() {
-                        let dim_u32_str =
-                            traverse_expression(ac, runtime, name, dimension, program_archive);
-                        dim_u32_vec.push(dim_u32_str.parse::<u32>().unwrap());
-                    }
-                    // treat_result_with_memory_error_void(
-                    //     valid_array_declaration(&arithmetic_values),
-                    //     meta,
-                    //     &mut runtime.runtime_errors,
-                    //     &runtime.call_trace,
-                    // )?;
-                    // let usable_dimensions =
-                    //     if let Option::Some(dimensions) = cast_indexing(&arithmetic_values) {
-                    //         dimensions
-                    //     } else {
-                    //         let err = Result::Err(ExecutionError::ArraySizeTooBig);
-                    //         treat_result_with_execution_error(
-                    //             err,
-                    //             meta,
-                    //             &mut runtime.runtime_errors,
-                    //             &runtime.call_trace,
-                    //         )?
-                    //     };
-                    match xtype {
-                        VariableType::Component => traverse_component_declaration(
-                            ac,
-                            runtime,
-                            name,
-                            &dim_u32_vec, // &usable_dimensions
-                                          // &mut runtime.environment,
-                                          // actual_node
-                        ),
-                        VariableType::Var => traverse_variable_declaration(
-                            ac,
-                            runtime,
-                            name,
-                            &dim_u32_vec, // &usable_dimensions
-                        ),
-                        VariableType::Signal(signal_type, tag_list) => traverse_signal_declaration(
-                            ac,
-                            runtime,
-                            name,
-                            *signal_type,
-                            &dim_u32_vec, // &usable_dimensions
-                        ),
-                        _ => {
-                            unreachable!()
-                        }
-                    }
+                VariableType::Component => {
+                    traverse_component_declaration(ac, runtime, name, &dim_u32_vec)
                 }
+                VariableType::Var => traverse_variable_declaration(ac, runtime, name, &dim_u32_vec),
+                VariableType::Signal(signal_type, _tag_list) => {
+                    traverse_signal_declaration(ac, runtime, name, *signal_type, &dim_u32_vec)
+                }
+                VariableType::AnonymousComponent => unimplemented!(),
             }
-            // Option::None
         }
-        IfThenElse {
-            cond,
-            if_case,
-            else_case,
-            ..
-        } => {
-            // let var = String::from("IFTHENELSE");
-            // ac.add_var(&var, SignalType::Intermediate);
-            // let lhs = traverse_expression(ac, &var, cond, program_archive);
-            // traverse_statement(ac, &if_case, program_archive);
-            // let else_case = else_case.as_ref().map(|e| e.as_ref());
-            // traverse_statement(ac, else_case.unwrap(), program_archive);
-            //     let else_case = else_case.as_ref().map(|e| e.as_ref());
-            //     let (possible_return, can_simplify, _) = execute_conditional_statement(
-            //         cond,
-            //         if_case,
-            //         else_case,
-            //         program_archive,
-            //         runtime,
-            //         actual_node,
-            //         flags
-            //     )?;
-            //     can_be_simplified = can_simplify;
-            //     possible_return
-            // }
-            // While { cond, stmt, .. } => loop {
-            //     let (returned, can_simplify, condition_result) = execute_conditional_statement(
-            //         cond,
-            //         stmt,
-            //         Option::None,
-            //         program_archive,
-            //         runtime,
-            //         actual_node,
-            //         flags
-            //     )?;
-            //     can_be_simplified &= can_simplify;
-            //     if returned.is_some() {
-            //         break returned;
-            //     } else if condition_result.is_none() {
-            //         let (returned, _, _) = execute_conditional_statement(
-            //             cond,
-            //             stmt,
-            //             None,
-            //             program_archive,
-            //             runtime,
-            //             actual_node,
-            //             flags
-            //         )?;
-            //         break returned;
-            //     } else if !condition_result.unwrap() {
-            //         break returned;
-            //     }
-        }
-        While { cond, stmt, .. } => loop {
+        Statement::While { cond, stmt, .. } => loop {
             let var = String::from("while");
             let (res, rb) = execute_expression(ac, runtime, &var, cond, program_archive);
             if res.contains("0") {
@@ -186,69 +83,8 @@ pub fn traverse_statement(
             }
             debug!("While res = {} {}", res, rb);
             traverse_statement(ac, runtime, stmt, program_archive);
-            // traverse_expression(ac, runtime, var, cond, program_archive);
-            // let var = String::from("while");
-            // ac.add_var(&var, SignalType::Intermediate);
-            // let lhs = traverse_expression(ac, runtime, &var, cond, program_archive);
-            // debug!("While cond {}", lhs);
-            // traverse_statement(ac, stmt, program_archive);
         },
-        ConstraintEquality { meta, lhe, rhe, .. } => {
-            // debug_assert!(actual_node.is_some());
-            // let f_left = execute_expression(lhe, program_archive, runtime, flags)?;
-            // let f_right = execute_expression(rhe, program_archive, runtime, flags)?;
-            // let arith_left = safe_unwrap_to_arithmetic_slice(f_left, line!());
-            // let arith_right = safe_unwrap_to_arithmetic_slice(f_right, line!());
-
-            // let correct_dims_result = AExpressionSlice::check_correct_dims(&arith_left, &Vec::new(), &arith_right, true);
-            // treat_result_with_memory_error_void(
-            //     correct_dims_result,
-            //     meta,
-            //     &mut runtime.runtime_errors,
-            //     &runtime.call_trace,
-            // )?;
-            // for i in 0..AExpressionSlice::get_number_of_cells(&arith_left){
-            //     let value_left = treat_result_with_memory_error(
-            //         AExpressionSlice::access_value_by_index(&arith_left, i),
-            //         meta,
-            //         &mut runtime.runtime_errors,
-            //         &runtime.call_trace,
-            //     )?;
-            //     let value_right = treat_result_with_memory_error(
-            //         AExpressionSlice::access_value_by_index(&arith_right, i),
-            //         meta,
-            //         &mut runtime.runtime_errors,
-            //         &runtime.call_trace,
-            //     )?;
-            //     let possible_non_quadratic =
-            //         AExpr::sub(
-            //             &value_left,
-            //             &value_right,
-            //             &runtime.constants.get_p()
-            //         );
-            //     if possible_non_quadratic.is_nonquadratic() {
-            //         treat_result_with_execution_error(
-            //             Result::Err(ExecutionError::NonQuadraticConstraint),
-            //             meta,
-            //             &mut runtime.runtime_errors,
-            //             &runtime.call_trace,
-            //         )?;
-            //     }
-            //     let quadratic_expression = possible_non_quadratic;
-            //     let constraint_expression = AExpr::transform_expression_to_constraint_form(
-            //         quadratic_expression,
-            //         runtime.constants.get_p(),
-            //     )
-            //     .unwrap();
-            //     if let Option::Some(node) = actual_node {
-            //         node.add_constraint(constraint_expression);
-            //     }
-            // }
-            // Option::None
-        }
-        Return { value, .. } => {}
-        Assert { arg, meta, .. } => {}
-        Substitution {
+        Statement::Substitution {
             meta,
             var,
             access,
@@ -277,16 +113,10 @@ pub fn traverse_statement(
             debug!("Sub Assigning {} to {}", rhs, &name_access);
             execute_statement(ac, runtime, stmt, program_archive);
         }
-        Block { stmts, .. } => {
+        Statement::Block { stmts, .. } => {
             traverse_sequence_of_statements(ac, runtime, stmts, program_archive, true);
         }
-        LogCall { args, .. } => {}
-        UnderscoreSubstitution { meta, rhe, op } => {
-            debug!("UnderscoreSubstitution found");
-        }
-        _ => {
-            unimplemented!()
-        }
+        _ => unimplemented!("Statement not implemented"),
     }
 }
 
@@ -295,13 +125,11 @@ pub fn traverse_expression(
     ac: &mut ArithmeticCircuit,
     runtime: &mut Runtime,
     var: &String,
-    expr: &Expression,
+    expression: &Expression,
     program_archive: &ProgramArchive,
 ) -> String {
-    use Expression::*;
-    // let mut can_be_simplified = true;
-    match expr {
-        Number(_, value) => {
+    match expression {
+        Expression::Number(_, value) => {
             // Declaring a constant.
             let val = value.to_u32().unwrap();
             debug!("Number value {}", val);
@@ -314,12 +142,11 @@ pub fn traverse_expression(
 
             val.to_string()
         }
-        InfixOp {
+        Expression::InfixOp {
             meta,
             lhe,
             infix_op,
             rhe,
-            ..
         } => {
             let ctx = runtime.get_current_context().unwrap();
             //TODO: for generic handling we should generate a name for an intermediate expression, we could ideally use only the values returned
@@ -337,7 +164,7 @@ pub fn traverse_expression(
             }
             var.to_string()
         }
-        PrefixOp {
+        Expression::PrefixOp {
             meta,
             prefix_op,
             rhe,
@@ -345,14 +172,14 @@ pub fn traverse_expression(
             debug!("Prefix found");
             var.to_string()
         }
-        InlineSwitchOp {
+        Expression::InlineSwitchOp {
             meta,
             cond,
             if_true,
             if_false,
         } => todo!(),
-        ParallelOp { meta, rhe } => todo!(),
-        Variable { meta, name, access } => {
+        Expression::ParallelOp { meta, rhe } => todo!(),
+        Expression::Variable { meta, name, access } => {
             let mut name_access = String::from(name);
             debug!("Variable found {}", name.to_string());
             for a in access.iter() {
@@ -385,12 +212,12 @@ pub fn traverse_expression(
             }
             name_access.to_string()
         }
-        Call { meta, id, args } => {
+        Expression::Call { meta, id, args } => {
             debug!("Call found {}", id.to_string());
-            // find the template and execute it
+            // TODO: Find the template and execute it
             id.to_string()
         }
-        AnonymousComp {
+        Expression::AnonymousComp {
             meta,
             id,
             is_parallel,
@@ -398,12 +225,12 @@ pub fn traverse_expression(
             signals,
             names,
         } => todo!(),
-        ArrayInLine { meta, values } => {
+        Expression::ArrayInLine { meta, values } => {
             debug!("ArrayInLine found");
             var.to_string()
         }
-        Tuple { meta, values } => todo!(),
-        UniformArray {
+        Expression::Tuple { meta, values } => todo!(),
+        Expression::UniformArray {
             meta,
             value,
             dimension,
@@ -458,9 +285,7 @@ pub fn traverse_component_declaration(
     comp_name: &str,
     dim_u32_vec: &Vec<u32>,
 ) {
-    // let var_id = runtime.assign_var_to_current_context(&var_name.to_string());
-    // ac.add_var(var_id, comp_name.to_string().as_str());
-    debug!("Found component {}", comp_name);
+    todo!()
 }
 
 /// Processes a signal declaration, integrating it into the circuit's variable management system.
@@ -487,17 +312,6 @@ pub fn traverse_variable_declaration(
         let signal_id = ctx.declare_signal(var_name).unwrap();
         ac.add_var(signal_id, var_name.to_string().as_str());
     } else {
-        // let mut all_accesses = Vec::new();
-        // for u32s in dim_u32_vec.iter() {
-        //     let mut accesses = Vec::new();
-        //     for i in 0..*u32s {
-        //         accesses.push(i);
-        //     }
-        //     all_accesses.push(accesses);
-        // }
-        // for accesses in all_accesses.iter() {
-
-        // }
         let dim_u32 = *dim_u32_vec.last().unwrap();
         for i in 0..dim_u32 {
             let (name, id) = ctx

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -77,7 +77,7 @@ pub fn traverse_statement(
         Statement::While { cond, stmt, .. } => loop {
             let var = String::from("while");
             let (res, rb) = execute_expression(ac, runtime, &var, cond, program_archive);
-            if res.contains("0") {
+            if res.contains('0') {
                 break;
             }
             debug!("While res = {} {}", res, rb);
@@ -94,7 +94,7 @@ pub fn traverse_statement(
                         debug!("Sub Array access found");
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
-                        name_access.push_str("_");
+                        name_access.push('_');
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Sub Change var name to {}", name_access);
                     }
@@ -168,7 +168,7 @@ pub fn traverse_expression(
                         debug!("Array access found");
                         let dim_u32_str =
                             traverse_expression(ac, runtime, var, expr, program_archive);
-                        name_access.push_str("_");
+                        name_access.push('_');
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Changed var name to {}", name_access);
                     }
@@ -184,7 +184,7 @@ pub fn traverse_expression(
                 // We're assuming data item is not an array
                 if let DataContent::Scalar(val) = data_item.get_content().unwrap() {
                     // TODO: Check if this is a constant
-                    let cloned_val = val.clone();
+                    let cloned_val = *val;
                     debug!("Return var value {} = {}", name_access, cloned_val);
                     ctx.declare_const(cloned_val).unwrap();
                     ac.add_const_var(cloned_val, cloned_val);
@@ -284,7 +284,7 @@ pub fn traverse_variable_declaration(
         let dim_u32 = *dim_u32_vec.last().unwrap();
         for i in 0..dim_u32 {
             let (name, id) = ctx
-                .declare_signal_array(&var_name.to_string(), vec![i])
+                .declare_signal_array(var_name, vec![i])
                 .unwrap();
             ac.add_var(id, &name);
         }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -71,7 +71,7 @@ pub fn traverse_statement(
                 VariableType::Signal(signal_type, _tag_list) => {
                     traverse_signal_declaration(ac, runtime, name, *signal_type, &dim_u32_vec)
                 }
-                VariableType::AnonymousComponent => unimplemented!(),
+                _ => unimplemented!(),
             }
         }
         Statement::While { cond, stmt, .. } => loop {

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -20,7 +20,7 @@ pub fn traverse_sequence_of_statements(
     runtime: &mut Runtime,
     stmts: &[Statement],
     program_archive: &ProgramArchive,
-    is_complete_template: bool,
+    _is_complete_template: bool,
 ) {
     for stmt in stmts.iter() {
         traverse_statement(ac, runtime, stmt, program_archive);
@@ -44,7 +44,6 @@ pub fn traverse_statement(
             }
         }
         Statement::Declaration {
-            meta,
             xtype,
             name,
             dimensions,
@@ -85,12 +84,7 @@ pub fn traverse_statement(
             traverse_statement(ac, runtime, stmt, program_archive);
         },
         Statement::Substitution {
-            meta,
-            var,
-            access,
-            op,
-            rhe,
-            ..
+            var, access, rhe, ..
         } => {
             let mut name_access = String::from(var);
             debug!("Sub Variable found {}", var.to_string());
@@ -104,8 +98,8 @@ pub fn traverse_statement(
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Sub Change var name to {}", name_access);
                     }
-                    Access::ComponentAccess(name) => {
-                        debug!("Sub Component access not handled");
+                    Access::ComponentAccess(_) => {
+                        todo!("Sub Component access not handled");
                     }
                 }
             }
@@ -143,10 +137,7 @@ pub fn traverse_expression(
             val.to_string()
         }
         Expression::InfixOp {
-            meta,
-            lhe,
-            infix_op,
-            rhe,
+            lhe, infix_op, rhe, ..
         } => {
             let ctx = runtime.get_current_context().unwrap();
             //TODO: for generic handling we should generate a name for an intermediate expression, we could ideally use only the values returned
@@ -164,22 +155,11 @@ pub fn traverse_expression(
             }
             var.to_string()
         }
-        Expression::PrefixOp {
-            meta,
-            prefix_op,
-            rhe,
-        } => {
+        Expression::PrefixOp { .. } => {
             debug!("Prefix found");
             var.to_string()
         }
-        Expression::InlineSwitchOp {
-            meta,
-            cond,
-            if_true,
-            if_false,
-        } => todo!(),
-        Expression::ParallelOp { meta, rhe } => todo!(),
-        Expression::Variable { meta, name, access } => {
+        Expression::Variable { name, access, .. } => {
             let mut name_access = String::from(name);
             debug!("Variable found {}", name.to_string());
             for a in access.iter() {
@@ -192,8 +172,9 @@ pub fn traverse_expression(
                         name_access.push_str(dim_u32_str.as_str());
                         debug!("Changed var name to {}", name_access);
                     }
-                    Access::ComponentAccess(name) => {
+                    Access::ComponentAccess(_) => {
                         debug!("Component access found");
+                        todo!()
                     }
                 }
             }
@@ -212,32 +193,20 @@ pub fn traverse_expression(
             }
             name_access.to_string()
         }
-        Expression::Call { meta, id, args } => {
+        Expression::Call { id, .. } => {
             debug!("Call found {}", id.to_string());
             // TODO: Find the template and execute it
             id.to_string()
         }
-        Expression::AnonymousComp {
-            meta,
-            id,
-            is_parallel,
-            params,
-            signals,
-            names,
-        } => todo!(),
-        Expression::ArrayInLine { meta, values } => {
+        Expression::ArrayInLine { .. } => {
             debug!("ArrayInLine found");
             var.to_string()
         }
-        Expression::Tuple { meta, values } => todo!(),
-        Expression::UniformArray {
-            meta,
-            value,
-            dimension,
-        } => {
+        Expression::UniformArray { .. } => {
             debug!("UniformArray found");
             var.to_string()
         }
+        _ => unimplemented!("Expression not implemented"),
     }
 }
 
@@ -280,10 +249,10 @@ pub fn traverse_infix_op(
 
 /// Processes the declaration of a component.
 pub fn traverse_component_declaration(
-    ac: &mut ArithmeticCircuit,
-    runtime: &mut Runtime,
-    comp_name: &str,
-    dim_u32_vec: &Vec<u32>,
+    _ac: &mut ArithmeticCircuit,
+    _runtime: &mut Runtime,
+    _comp_name: &str,
+    _dim_u32_vec: &Vec<u32>,
 ) {
     todo!()
 }
@@ -293,7 +262,7 @@ pub fn traverse_signal_declaration(
     ac: &mut ArithmeticCircuit,
     runtime: &mut Runtime,
     signal_name: &str,
-    signal_type: SignalType,
+    _signal_type: SignalType,
     dim_u32_vec: &Vec<u32>,
 ) {
     traverse_variable_declaration(ac, runtime, signal_name, dim_u32_vec);


### PR DESCRIPTION
# Description

This PR aims to remove unused code to make the navigation easier and implement some simplifications to existing conditional, `match` blocks and other structs. It removes every compiler linting bypasses and fixes every `clippy` warning.

It also includes a new workflow for building, verifying clippy warnings and tests.