### PR TITLE
fix: substitutions processing

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -77,13 +77,26 @@ pub fn execute_statement(
                 let ctx = runtime.get_current_context().unwrap();
                 let res = ctx.get_data_item(&name_access);
 
-                // Declare if it doesn't exist
-                if res.is_err() {
-                    ctx.declare_variable(&name_access).unwrap();
+                match res {
+                    Ok(data_item) => {
+                        if let Some(val) = data_item.get_content() {
+                            ctx.set_data_item(&name_access, val.clone()).unwrap();
+                        } else {
+                            // TODO: Review this, we're assigning a variable another's variable's name
+                            ctx.set_data_item(
+                                &name_access,
+                                DataContent::Scalar(rhs.parse().unwrap()),
+                            )
+                            .unwrap();
+                        }
+                    }
+                    Err(_) => {
+                        ctx.declare_variable(&name_access).unwrap();
+                        // TODO: Review this, we're assigning a variable another's variable's name
+                        ctx.set_data_item(&name_access, DataContent::Scalar(rhs.parse().unwrap()))
+                            .unwrap();
+                    }
                 }
-
-                ctx.set_data_item(&name_access, DataContent::Scalar(rhs.parse().unwrap()))
-                    .unwrap();
             }
         }
         Statement::Return { value, .. } => {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -4,10 +4,7 @@
 
 use crate::circuit::{AGateType, ArithmeticCircuit};
 use crate::runtime::{DataContent, DataType, Runtime};
-use crate::traverse::{
-    traverse_component_declaration, traverse_sequence_of_statements, traverse_signal_declaration,
-    traverse_variable_declaration,
-};
+use crate::traverse::{traverse_declaration, traverse_sequence_of_statements};
 use circom_circom_algebra::num_traits::ToPrimitive;
 use circom_program_structure::ast::{
     Access, Expression, ExpressionInfixOpcode, Statement, VariableType,
@@ -52,11 +49,11 @@ pub fn execute_statement(
 
             match xtype {
                 VariableType::Component => {
-                    traverse_component_declaration(ac, runtime, name, &dim_u32_vec)
+                    todo!("Component declaration not handled")
                 }
-                VariableType::Var => traverse_variable_declaration(ac, runtime, name, &dim_u32_vec),
-                VariableType::Signal(signal_type, _tag_list) => {
-                    traverse_signal_declaration(ac, runtime, name, *signal_type, &dim_u32_vec)
+                VariableType::Var => traverse_declaration(ac, runtime, name, xtype, &dim_u32_vec),
+                VariableType::Signal(_, _) => {
+                    traverse_declaration(ac, runtime, name, xtype, &dim_u32_vec)
                 }
                 _ => unimplemented!(),
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -171,6 +171,18 @@ impl Context {
         }
     }
 
+    /// Declares a new variable.
+    pub fn declare_variable(&mut self, name: &str) -> Result<(), RuntimeError> {
+        if self.values.contains_key(name) {
+            Err(RuntimeError::DataItemAlreadyDeclared)
+        } else {
+            debug!("Declaring variable '{}'", name);
+            self.values
+                .insert(name.to_string(), DataItem::new(DataType::Variable));
+            Ok(())
+        }
+    }
+
     /// Declares a new signal.
     pub fn declare_signal(&mut self, name: &str) -> Result<u32, RuntimeError> {
         let signal_id = self.generate_id();
@@ -243,6 +255,17 @@ impl Context {
         let signal_id = self.declare_signal(&signal_name)?;
 
         Ok((signal_name, signal_id))
+    }
+
+    /// Creates a unique variable for an array element based on its indices and assigns it a unique identifier.
+    pub fn declare_var_array(&mut self, name: &str, indices: Vec<u32>) -> Result<(), RuntimeError> {
+        let mut var_name = name.to_string();
+
+        for indice in indices {
+            var_name.push_str(&format!("_{}", indice));
+        }
+
+        self.declare_variable(name)
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -344,8 +344,8 @@ impl DataItem {
     }
 
     /// Gets the data type of the data item.
-    pub fn get_data_type(&self) -> &DataType {
-        &self.data_type
+    pub fn get_data_type(&self) -> DataType {
+        self.data_type.clone()
     }
 
     /// Checks if the content of the data item is an array.

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -55,7 +55,7 @@ pub fn traverse_statement(
             let dim_u32_vec: Vec<u32> = dimensions
                 .iter()
                 .map(|dimension| {
-                    let (dim_u32_str, dim_u32_bool) =
+                    let (dim_u32_str, _) =
                         execute_expression(ac, runtime, name, dimension, program_archive);
                     dim_u32_str
                         .parse::<u32>()
@@ -90,16 +90,16 @@ pub fn traverse_statement(
             ..
         } => {
             let var = String::from("IFTHENELSE");
-            let (res, resb) = execute_expression(ac, runtime, &var, cond, program_archive);
+            let (res, _) = execute_expression(ac, runtime, &var, cond, program_archive);
             let else_case = else_case.as_ref().map(|e| e.as_ref());
-            if res.contains("0") {
+            if res.contains('0') {
                 if let Option::Some(else_stmt) = else_case {
                     traverse_statement(ac, runtime, else_stmt, program_archive);
                 }
             } else {
                 traverse_statement(ac, runtime, if_case, program_archive)
             }
-        },
+        }
         Statement::Substitution {
             var, access, rhe, ..
         } => {
@@ -209,31 +209,31 @@ pub fn traverse_expression(
             }
             name_access.to_string()
         }
-        Expression::Call { meta, id, args } => {
-            println!("Call found {}", id.to_string());
+        Expression::Call { id, args, .. } => {
+            println!("Call found {}", id);
 
             // HERE IS CODE FOR ARGUMENTS
-            
+
             let functions = _program_archive.get_function_names();
             let arg_names = if functions.contains(id) {
                 _program_archive.get_function_data(id).get_name_of_params()
             } else {
                 _program_archive.get_template_data(id).get_name_of_params()
             };
-            
+
             for (arg_name, arg_value) in arg_names.iter().zip(args) {
                 // We set arg_name to have arg_value
-                let (res, resb) = execute_expression(ac, runtime, arg_name, arg_value, _program_archive);
+                let (_, _) = execute_expression(ac, runtime, arg_name, arg_value, _program_archive);
                 // TODO: set res to arg_name
             }
 
             // HERE IS CODE FOR FUNCTIGON
 
-            let function_boby = _program_archive.get_function_data(id).get_body_as_vec();
-            traverse_sequence_of_statements(ac, runtime, &function_boby, _program_archive, true);
+            let fn_body = _program_archive.get_function_data(id).get_body_as_vec();
+            traverse_sequence_of_statements(ac, runtime, fn_body, _program_archive, true);
 
             // HERE IS CODE FOR TEMPLATE
-            
+
             // find the template and execute it
             // let template_body = program_archive.get_template_data(id).get_body_as_vec();
 

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -18,12 +18,12 @@ use log::debug;
 pub fn traverse_sequence_of_statements(
     ac: &mut ArithmeticCircuit,
     runtime: &mut Runtime,
-    stmts: &[Statement],
+    statements: &[Statement],
     program_archive: &ProgramArchive,
     _is_complete_template: bool,
 ) {
-    for stmt in stmts.iter() {
-        traverse_statement(ac, runtime, stmt, program_archive);
+    for statement in statements {
+        traverse_statement(ac, runtime, statement, program_archive);
     }
     // TODO: handle complete template
 }
@@ -197,14 +197,16 @@ pub fn traverse_expression(
             let ctx = runtime.get_current_context().unwrap();
             if ctx.get_data_item(&name_access).is_ok() {
                 let data_item = ctx.get_data_item(&name_access).unwrap();
-                // We're assuming data item is not an array
-                if let DataContent::Scalar(val) = data_item.get_content().unwrap() {
-                    // TODO: Check if this is a constant
-                    let cloned_val = *val;
-                    debug!("Return var value {} = {}", name_access, cloned_val);
-                    ctx.declare_const(cloned_val).unwrap();
-                    ac.add_const_var(cloned_val, cloned_val);
-                    return cloned_val.to_string();
+                if data_item.get_content().is_some() {
+                    // We're assuming data item is not an array
+                    if let DataContent::Scalar(val) = data_item.get_content().unwrap() {
+                        // TODO: Check if this is a constant
+                        let cloned_val = *val;
+                        debug!("Return var value {} = {}", name_access, val);
+                        ctx.declare_const(cloned_val).unwrap();
+                        ac.add_const_var(cloned_val, cloned_val);
+                        return cloned_val.to_string();
+                    }
                 }
             }
             name_access.to_string()


### PR DESCRIPTION
# Description

This PR introduces some changes to fix the way we were processing substitutions:

- Removes declaration statement handling from `execute_statement` function, this shouldn't happen.
- Updates the way we're assigning variables when executing a statement.
- Adds some useful methods to the runtime module.
- Fixes the way we're handling variable and signal declarations.