### PR TITLE
fix: infix operation handling

### DIFF
--- a/src/assets/circuit.circom
+++ b/src/assets/circuit.circom
@@ -1,27 +1,15 @@
 pragma circom 2.0.0;
 
 template InnerProd () {  
-
-   // Declaration of signals 
-   signal input input_A[3];  
-   signal input input_B[3];  
+   signal input input_A;  
+   signal input input_B;  
    signal output ip;
 
-   signal sum[3];
+   var variable_A;
 
-   sum[0] <== input_A[0]*input_B[0];
+   variable_A = 100;
 
-   // for (var i = 1; i < 3; i++) {
-   //    sum[i] <== sum[i-1] + input_A[i] * input_B[i];
-   // }
-
-   // var sum = 0;
-
-   // for (var i = 0; i < 3; i++) {
-   //    sum = sum + input_A[i]*input_B[i];
-   // }
-
-   ip <== sum[2];
+   ip <== input_A + input_B + variable_A;
 }
 
 component main = InnerProd();

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -74,10 +74,10 @@ pub struct ArithmeticVar {
 }
 
 impl ArithmeticVar {
-    pub fn new(_var_id: u32, _var_name: String) -> ArithmeticVar {
-        ArithmeticVar {
-            var_id: _var_id,
-            var_name: _var_name,
+    pub fn new(var_id: u32, var_name: String) -> Self {
+        Self {
+            var_id,
+            var_name,
             is_const: false,
             const_value: 0,
         }
@@ -100,19 +100,20 @@ pub struct ArithmeticNode {
 }
 
 impl ArithmeticNode {
+    /// Creates a new arithmetic node.
     pub fn new(
-        _gate_id: u32,
-        _gate_type: AGateType,
-        _input_lhs_id: u32,
-        _input_rhs_id: u32,
-        _out_put_id: u32,
-    ) -> ArithmeticNode {
-        ArithmeticNode {
-            gate_id: _gate_id,
-            gate_type: _gate_type,
-            input_lhs_id: _input_lhs_id,
-            input_rhs_id: _input_rhs_id,
-            output_id: _out_put_id,
+        gate_id: u32,
+        gate_type: AGateType,
+        input_lhs_id: u32,
+        input_rhs_id: u32,
+        output_id: u32,
+    ) -> Self {
+        Self {
+            gate_id,
+            gate_type,
+            input_lhs_id,
+            input_rhs_id,
+            output_id,
         }
     }
 }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -88,14 +88,12 @@ pub fn execute_statement(
                     if let Some(val) = data_item.get_content() {
                         ctx.set_data_item(&name_access, val.clone())?;
                     } else {
-                        // TODO: Review this, we're assigning a variable another's variable's name
                         ctx.set_data_item(&name_access, DataContent::Scalar(rhs))?;
                     }
                     Ok(())
                 }
                 Err(_) => {
                     ctx.declare_variable(&name_access)?;
-                    // TODO: Review this, we're assigning a variable another's variable's name
                     ctx.set_data_item(&name_access, DataContent::Scalar(rhs))?;
                     Ok(())
                 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -4,10 +4,11 @@
 
 use crate::circuit::ArithmeticCircuit;
 use crate::compiler::{analyse_project, parse_project, Input};
-use crate::runtime::Runtime;
+use crate::runtime::{Runtime, RuntimeError};
 use crate::traverse::traverse_sequence_of_statements;
 use circom_program_structure::ast::Expression;
 use circom_program_structure::program_archive::ProgramArchive;
+use thiserror::Error;
 
 /// Parses a Circom file, processes its content, and sets up the necessary structures for circuit analysis.
 pub fn parse_circom() -> Result<(), &'static str> {
@@ -43,4 +44,21 @@ pub fn traverse_program(program_archive: &ProgramArchive) -> ArithmeticCircuit {
     };
 
     ac
+}
+
+/// Program errors
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+pub enum ProgramError {
+    #[error("Call error")]
+    CallError,
+    #[error("Parsing error")]
+    ParsingError,
+    #[error("Context error: {0}")]
+    RuntimeError(RuntimeError),
+}
+
+impl From<RuntimeError> for ProgramError {
+    fn from(e: RuntimeError) -> Self {
+        ProgramError::RuntimeError(e)
+    }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -11,12 +11,12 @@ use circom_program_structure::program_archive::ProgramArchive;
 use thiserror::Error;
 
 /// Parses a Circom file, processes its content, and sets up the necessary structures for circuit analysis.
-pub fn parse_circom() -> Result<(), &'static str> {
+pub fn parse_circom() -> Result<(), ProgramError> {
     let user_input = Input::default();
-    let mut program_archive = parse_project(&user_input).map_err(|_| "Parsing failed")?;
-    analyse_project(&mut program_archive).map_err(|_| "Analysis failed")?;
+    let mut program_archive = parse_project(&user_input).map_err(|_| ProgramError::ParsingError)?;
+    analyse_project(&mut program_archive).map_err(|_| ProgramError::AnalysisError)?;
 
-    let mut circuit = traverse_program(&program_archive);
+    let mut circuit = traverse_program(&program_archive)?;
 
     circuit.print_ac();
     circuit.truncate_zero_add_gate();
@@ -27,28 +27,32 @@ pub fn parse_circom() -> Result<(), &'static str> {
 }
 
 /// Traverses the program structure of a parsed Circom file and constructs an arithmetic circuit.
-pub fn traverse_program(program_archive: &ProgramArchive) -> ArithmeticCircuit {
-    let mut ac = ArithmeticCircuit::new();
-    let mut runtime = Runtime::new().unwrap();
+pub fn traverse_program(
+    program_archive: &ProgramArchive,
+) -> Result<ArithmeticCircuit, ProgramError> {
+    let mut circuit = ArithmeticCircuit::new();
+    let mut runtime = Runtime::new()?;
 
     if let Expression::Call { id, .. } = program_archive.get_main_expression() {
         let template_body = program_archive.get_template_data(id).get_body_as_vec();
 
         traverse_sequence_of_statements(
-            &mut ac,
+            &mut circuit,
             &mut runtime,
             template_body,
             program_archive,
             true,
-        );
+        )?;
     };
 
-    ac
+    Ok(circuit)
 }
 
 /// Program errors
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum ProgramError {
+    #[error("Analysis error")]
+    AnalysisError,
     #[error("Call error")]
     CallError,
     #[error("Parsing error")]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -355,7 +355,7 @@ impl DataItem {
 }
 
 /// Runtime errors
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum RuntimeError {
     #[error("Error retrieving context")]
     ContextRetrievalError,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -25,7 +25,7 @@ pub struct Runtime {
 impl Runtime {
     /// Constructs a new Runtime with an empty stack.
     pub fn new() -> Result<Self, RuntimeError> {
-        debug!("Creating new Runtime");
+        debug!("New runtime");
         Ok(Self {
             ctx_stack: vec![Context::new(0, 0, HashMap::new())?],
             current_ctx: 0,
@@ -35,7 +35,7 @@ impl Runtime {
 
     /// Creates a new context for a function call or similar operation.
     pub fn add_context(&mut self, origin: ContextOrigin) -> Result<(), RuntimeError> {
-        debug!("Adding new context for origin: {:?}", origin);
+        debug!("New context - origin: {:?}", origin);
         // Generate a unique ID for the new context
         let new_id = self.generate_context_id();
 
@@ -104,7 +104,7 @@ impl Context {
         caller_id: u32,
         values: HashMap<String, DataItem>,
     ) -> Result<Self, RuntimeError> {
-        debug!("Creating new context with id: {}", id);
+        debug!("New context - id: {}", id);
         Ok(Self {
             id,
             caller_id,
@@ -119,7 +119,7 @@ impl Context {
         name: &str,
         data_type: DataType,
     ) -> Result<(), RuntimeError> {
-        debug!("Declaring data item '{}' with type {:?}", name, data_type);
+        debug!("Declaring data item {} - {:?}", name, data_type);
         if self.values.contains_key(name) {
             Err(RuntimeError::DataItemAlreadyDeclared)
         } else {
@@ -132,7 +132,7 @@ impl Context {
     /// Assigns a value to a data item in the context.
     /// Returns an error if the data item is not found.
     pub fn set_data_item(&mut self, name: &str, content: DataContent) -> Result<(), RuntimeError> {
-        debug!("Setting content for data item '{}'", name);
+        debug!("Setting data item {} - {:?} ", name, content);
         match self.values.get_mut(name) {
             Some(data_item) => data_item.set_content(content),
             None => Err(RuntimeError::DataItemNotDeclared),
@@ -142,7 +142,7 @@ impl Context {
     /// Retrieves a reference to a data item by name.
     /// Returns an error if the data item is not found.
     pub fn get_data_item(&self, name: &str) -> Result<&DataItem, RuntimeError> {
-        debug!("Getting data item '{}'", name);
+        debug!("Getting data item {}", name);
         self.values
             .get(name)
             .ok_or(RuntimeError::DataItemNotDeclared)
@@ -151,7 +151,7 @@ impl Context {
     /// Removes a data item from the context.
     /// Returns an error if the data item is not found.
     pub fn remove_data_item(&mut self, name: &str) -> Result<(), RuntimeError> {
-        debug!("Removing data item '{}'", name);
+        debug!("Removing data item {}", name);
         if self.values.remove(name).is_some() {
             Ok(())
         } else {
@@ -162,7 +162,7 @@ impl Context {
     /// Clears the content of a data item in the context.
     /// Returns an error if the data item is not found.
     pub fn clear_data_item(&mut self, name: &str) -> Result<(), RuntimeError> {
-        debug!("Clearing content for data item '{}'", name);
+        debug!("Clearing data item {}", name);
         match self.values.get_mut(name) {
             Some(data_item) => {
                 data_item.clear_content();
@@ -174,7 +174,7 @@ impl Context {
 
     /// Declares a new variable.
     pub fn declare_variable(&mut self, name: &str) -> Result<(), RuntimeError> {
-        debug!("Declaring variable '{}'", name);
+        debug!("Declaring variable {}", name);
         if self.values.contains_key(name) {
             Err(RuntimeError::DataItemAlreadyDeclared)
         } else {
@@ -186,7 +186,7 @@ impl Context {
 
     /// Declares a new signal.
     pub fn declare_signal(&mut self, name: &str) -> Result<u32, RuntimeError> {
-        debug!("Declaring signal '{}'", name);
+        debug!("Declaring signal {}", name);
         let signal_id = self.generate_id();
         if self.values.contains_key(name) {
             Err(RuntimeError::DataItemAlreadyDeclared)
@@ -201,7 +201,7 @@ impl Context {
     /// Declares a new const value as a signal.
     /// Sets the value of the signal to the given value. This being the signal id.
     pub fn declare_const(&mut self, value: u32) -> Result<(), RuntimeError> {
-        debug!("Declaring const '{:?}'", value);
+        debug!("Declaring const {:?}", value);
         let const_name = value.to_string();
         if self.values.contains_key(&const_name) {
             Err(RuntimeError::DataItemAlreadyDeclared)
@@ -216,7 +216,7 @@ impl Context {
     /// Declares a new auto generated variable.
     pub fn declare_auto_var(&mut self) -> Result<String, RuntimeError> {
         let auto_name = format!("auto_var_{}", self.generate_id());
-        debug!("Declaring auto generated variable '{}'", auto_name);
+        debug!("Declaring auto generated variable {}", auto_name);
         if self.values.contains_key(&auto_name) {
             Err(RuntimeError::DataItemAlreadyDeclared)
         } else {
@@ -230,7 +230,7 @@ impl Context {
     pub fn declare_auto_signal(&mut self) -> Result<String, RuntimeError> {
         let signal_id = self.generate_id();
         let auto_name = format!("auto_signal_{}", signal_id);
-        debug!("Declaring auto generated signal '{}'", auto_name);
+        debug!("Declaring auto generated signal {}", auto_name);
         if self.values.contains_key(&auto_name) {
             Err(RuntimeError::DataItemAlreadyDeclared)
         } else {


### PR DESCRIPTION
# Description

This PR aims to fix the multi term infix operations processing. We're now able to process these operations and create the corresponding gates if necessary.

## Changes

- Remove every tuple return and replace with `Result`
- Implement `Result` return on functions without return, in order to remove unwraps and improve error handling.
- Update `execute_expression` to return a value of the processed expression.
- Update `execute_infix_op` to run the operation and return the result.
- Fix substitution handling in `execute_statement`.
- Remove unused variable name argument from `execute_expression` and `traverse_expression`.
- Implement `ProgramError`.
- Update runtime logs.
- Implement `declare_auto_signal` in the runtime.
