### PR TITLE
fix: number operations

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -48,10 +48,12 @@ pub enum ProgramError {
     IOError(#[from] io::Error),
     #[error("JSON serialization error: {0}")]
     JsonSerializationError(#[from] serde_json::Error),
-    #[error("Output directory creation error")]
-    OutputDirectoryCreationError,
+    #[error("Operation error: {0}")]
+    OperationError(String),
     #[error("Operation not supported")]
     OperationNotSupported,
+    #[error("Output directory creation error")]
+    OutputDirectoryCreationError,
     #[error("Parsing error")]
     ParsingError,
     #[error("Runtime error: {0}")]
@@ -59,4 +61,3 @@ pub enum ProgramError {
     #[error("Undefined function or template")]
     UndefinedFunctionOrTemplate,
 }
-

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,6 +8,8 @@ use rand::{thread_rng, Rng};
 use std::collections::{HashMap, HashSet, VecDeque};
 use thiserror::Error;
 
+pub const RETURN_VAR: &str = "function_return_value";
+
 /// Data type
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DataType {
@@ -152,6 +154,12 @@ impl Context {
             if self.variables.contains_key(name) {
                 self.variables.insert(name.clone(), variable.clone());
             }
+        }
+
+        // Force the merge of the return variable.
+        if child.variables.contains_key(RETURN_VAR) {
+            self.variables
+                .insert(RETURN_VAR.to_string(), child.variables[RETURN_VAR].clone());
         }
 
         for (name, component) in &child.components {


### PR DESCRIPTION
# Description

This pull request updates the `execute_op` function in order to enable every operation to be made between integers and not limit this to `AGateType`.

It also includes a fix to merge function return variables whenever changing contexts.

## Related Issues

- Resolves #27 