### PR TITLE
feat: update node and signal id to u128

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -161,7 +161,7 @@ pub fn process_statement(
                     let given_output_id = ctx.get_signal_id(&lh_access)?;
                     let gate_output_id = get_signal_for_access(ac, ctx, &rh_access)?;
                     let a_name = lh_access.access_str(ctx.get_ctx_name());
-                    let b_name =  rh_access.access_str(ctx.get_ctx_name());
+                    let b_name = rh_access.access_str(ctx.get_ctx_name());
                     ac.add_connection(gate_output_id, given_output_id, a_name, b_name)?;
                 }
                 DataType::Variable => {
@@ -181,7 +181,7 @@ pub fn process_statement(
                         let assigned_signal = get_signal_for_access(ac, ctx, &rh_access)?;
 
                         let a_name = lh_access.access_str(ctx.get_ctx_name());
-                        let b_name =  rh_access.access_str(ctx.get_ctx_name());
+                        let b_name = rh_access.access_str(ctx.get_ctx_name());
 
                         ac.add_connection(assigned_signal, component_signal, a_name, b_name)?;
                     }
@@ -204,7 +204,7 @@ pub fn process_statement(
 
             Ok(())
         }
-        _ => todo!()
+        _ => todo!(),
     }
 }
 
@@ -235,7 +235,7 @@ pub fn process_expression(
         Expression::Variable { name, access, .. } => {
             build_access(ac, runtime, program_archive, name, access)
         }
-        _ => todo!()
+        _ => todo!(),
     }
 }
 
@@ -376,10 +376,8 @@ fn handle_infix_op(
     match op {
         ExpressionInfixOpcode::Lesser => {
             println!("DEBUG ALt");
-        },
-        _ => {
-
         }
+        _ => {}
     }
 
     // Handle cases where one or both inputs are signals
@@ -398,7 +396,9 @@ fn handle_infix_op(
     let rh_name = rhe_access.access_str(ctx.get_ctx_name());
     let o_name = output_signal.access_str(ctx.get_ctx_name());
 
-    ac.add_gate(gate_type, lhs_id, rhs_id, output_id, lh_name, rh_name, o_name)?;
+    ac.add_gate(
+        gate_type, lhs_id, rhs_id, output_id, lh_name, rh_name, o_name,
+    )?;
 
     Ok(output_signal)
 }
@@ -410,7 +410,7 @@ fn get_signal_for_access(
     ac: &mut ArithmeticCircuit,
     ctx: &Context,
     access: &DataAccess,
-) -> Result<u32, ProgramError> {
+) -> Result<u128, ProgramError> {
     match ctx.get_item_data_type(&access.get_name())? {
         DataType::Signal => Ok(ctx.get_signal_id(access)?),
         DataType::Variable => {
@@ -418,7 +418,7 @@ fn get_signal_for_access(
                 .get_variable_value(access)?
                 .ok_or(ProgramError::EmptyDataItem)?;
             ac.add_const(value, access.access_str(ctx.get_ctx_name()))?;
-            Ok(value)
+            Ok(value as u128)
         }
         DataType::Component => Ok(ctx.get_component_signal_id(access)?),
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,7 +5,10 @@
 use crate::program::ProgramError;
 use circom_program_structure::ast::VariableType;
 use rand::{thread_rng, Rng};
-use std::{collections::{HashMap, HashSet, VecDeque}, fmt::Write};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    fmt::Write,
+};
 use thiserror::Error;
 
 pub const RETURN_VAR: &str = "function_return_value";
@@ -276,7 +279,7 @@ impl Context {
     }
 
     /// Gets the id of the signal at the specified index path.
-    pub fn get_signal_id(&self, access: &DataAccess) -> Result<u32, RuntimeError> {
+    pub fn get_signal_id(&self, access: &DataAccess) -> Result<u128, RuntimeError> {
         let signal = self
             .signals
             .get(&access.name)
@@ -305,7 +308,7 @@ impl Context {
     }
 
     /// Gets the id of a component's signal.
-    pub fn get_component_signal_id(&self, access: &DataAccess) -> Result<u32, RuntimeError> {
+    pub fn get_component_signal_id(&self, access: &DataAccess) -> Result<u128, RuntimeError> {
         let (component_access, signal_access) = process_component_access(access)?;
         let component =
             self.components
@@ -342,18 +345,18 @@ impl Context {
 /// Represents a signal that holds a single id or a nested structure of values with unique IDs.
 #[derive(Clone, Debug)]
 pub struct Signal {
-    value: NestedValue<u32>,
+    value: NestedValue<u128>,
 }
 
 impl Signal {
     /// Constructs a new Signal as a nested structure based on provided dimensions.
     fn new(dimensions: &[u32]) -> Self {
-        fn create_nested_signal(dimensions: &[u32]) -> NestedValue<u32> {
+        fn create_nested_signal(dimensions: &[u32]) -> NestedValue<u128> {
             if let Some((&first, rest)) = dimensions.split_first() {
                 let array = (0..first).map(|_| create_nested_signal(rest)).collect();
                 NestedValue::Array(array)
             } else {
-                NestedValue::Value(generate_u32())
+                NestedValue::Value(generate_u128())
             }
         }
 
@@ -363,7 +366,7 @@ impl Signal {
     }
 
     /// Retrieves the ID of the signal at the specified index path.
-    fn get(&self, index_path: &[u32]) -> Result<u32, RuntimeError> {
+    fn get(&self, index_path: &[u32]) -> Result<u128, RuntimeError> {
         get_nested_value(&self.value, index_path)
     }
 }
@@ -444,7 +447,7 @@ impl Component {
         &self,
         component_access: &[u32],
         signal_access: &DataAccess,
-    ) -> Result<u32, RuntimeError> {
+    ) -> Result<u128, RuntimeError> {
         let map = get_nested_value(&self.signal_map, component_access)?;
         let signal = map
             .get(&signal_access.get_name())
@@ -508,7 +511,7 @@ impl DataAccess {
                 }
             }
         }
-       ret
+        ret
     }
 }
 
@@ -644,6 +647,11 @@ pub fn increment_indices(indices: &mut Vec<u32>, limits: &[u32]) -> Result<bool,
 
 /// Generates a random u32.
 pub fn generate_u32() -> u32 {
+    thread_rng().gen()
+}
+
+/// Generates a random u128.
+pub fn generate_u128() -> u128 {
     thread_rng().gen()
 }
 


### PR DESCRIPTION
# Description

This PR points to the 0.09 release. It updates the node signal ids to be `u128` instead of `u32`.

## Related Issues

-  #33 