### PR TITLE
Update getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo build --release
 - Run the compilation
 
 ```
-cargo run
+cargo run --release
 ```
 
 ## Configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use circom_2_arithc::{
     program::{build_circuit, ProgramError},
 };
 use dotenv::dotenv;
-use env_logger::init_from_env;
+use env_logger::{init_from_env, Env};
 use serde_json::to_string;
 use std::{
     fs::{self, File},
@@ -12,8 +12,8 @@ use std::{
 };
 
 fn main() -> Result<(), ProgramError> {
-    optional_dotenv();
-    init_from_env("LOG_LEVEL=info");
+    dotenv().ok();
+    init_from_env(Env::default().filter_or("LOG_LEVEL", "info"));
 
     let output_path = PathBuf::from(view().value_of("output").unwrap());
 
@@ -31,23 +31,4 @@ fn main() -> Result<(), ProgramError> {
     File::create(output_file_path)?.write_all(circuit_json.as_bytes())?;
 
     Ok(())
-}
-
-fn optional_dotenv() -> () {
-    let env_error = match dotenv() {
-        Ok(_) => None,
-        Err(e) => match &e {
-            dotenv::Error::Io(io_error) => match io_error.kind() {
-                // Allow missing .env file
-                std::io::ErrorKind::NotFound => Some(e),
-
-                _ => Some(e),
-            },
-            _ => Some(e),
-        }
-    };
-
-    if let Some(env_error) = env_error {
-        panic!("Failed to initialize environment: {}", env_error);
-    }
 }


### PR DESCRIPTION
I found that following the getting started guide was a bit clunky:
- It said to do `cargo build --release` followed by `cargo run`, which unnecessarily builds release and then lazily builds the debug version
- A `.env` file was required even though it wasn't necessary to do compilation

This PR fixes both:
- Use `--release` consistently in README
- Allow for missing .env file