### PR TITLE
feat: sim circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rand = "0.8.5"
 regex = "1.10.3"
 serde_json = "1.0"
 serde = { version = "1.0.196", features = ["derive"] } 
-thiserror = "1.0.56"
+thiserror = "1.0.59"
 
 # DSL
 circom-circom_algebra =  { git = "https://github.com/iden3/circom", package = "circom_algebra"}
@@ -29,8 +29,9 @@ circom-program_structure =  { git = "https://github.com/iden3/circom", package =
 circom-type_analysis =  { git = "https://github.com/iden3/circom", package = "type_analysis"}
 
 # MPZ
-mpz-circuits =  { git = "https://github.com/privacy-scaling-explorations/mpz", package = "mpz-circuits"}
-bmr16-mpz = { git = "https://github.com/tkmct/mpz", package = "mpz-circuits"}
+mpz-circuits =  { git = "https://github.com/privacy-scaling-explorations/mpz", package = "mpz-circuits" }
+bmr16-mpz = { git = "https://github.com/tkmct/mpz", package = "mpz-circuits" }
+sim-circuit = { git = "https://github.com/brech1/sim-circuit" }
 
 [[bin]]
 name="circom"

--- a/tests/mat_elem_mul.rs
+++ b/tests/mat_elem_mul.rs
@@ -6,10 +6,9 @@ const TEST_FILE_PATH: &str = "./tests/circuits/matElemMul.circom";
 fn test_matrix_element_multiplication() {
     let input = Input::new(TEST_FILE_PATH.into(), "./".into()).unwrap();
     let circuit = build_circuit(&input).unwrap();
-    let report = circuit.generate_circuit_report().unwrap();
-    let mpz_circuit = circuit.build_mpz_circuit(&report).unwrap();
+    let mut sim_circuit = circuit.build_sim_circuit().unwrap();
 
     let circuit_input = vec![2, 2, 2, 2, 2, 2, 2, 2];
-    let res = mpz_circuit.evaluate(&circuit_input).unwrap();
+    let res = sim_circuit.execute(&circuit_input).unwrap();
     assert_eq!(res, vec![4, 4, 4, 4]);
 }

--- a/tests/sum.rs
+++ b/tests/sum.rs
@@ -6,10 +6,9 @@ const TEST_FILE_PATH: &str = "./tests/circuits/sum.circom";
 fn test_sum() {
     let input = Input::new(TEST_FILE_PATH.into(), "./".into()).unwrap();
     let circuit = build_circuit(&input).unwrap();
-    let report = circuit.generate_circuit_report().unwrap();
-    let mpz_circuit = circuit.build_mpz_circuit(&report).unwrap();
+    let mut sim_circuit = circuit.build_sim_circuit().unwrap();
 
     let circuit_input = vec![1, 2];
-    let res = mpz_circuit.evaluate(&circuit_input).unwrap();
+    let res = sim_circuit.execute(&circuit_input).unwrap();
     assert_eq!(res, vec![3]);
 }


### PR DESCRIPTION
# Description

This PR updates the integration test to use the `sim-circuit` generic circuit execution tool.

It also adds a new method to build the `SimCircuit` struct from our `ArithmeticCircuit`. 