### PR TITLE
feat: update circuit evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.196", features = ["derive"] }
 thiserror = "1.0.59"
 strum_macros = "0.26.4"
 strum = "0.26.2"
+sim-circuit = { git = "https://github.com/brech1/sim-circuit", branch = "feat/generic-circuit" }
 
 # DSL
 circom-circom_algebra = { git = "https://github.com/iden3/circom", package = "circom_algebra" }
@@ -29,8 +30,3 @@ circom-dag = { git = "https://github.com/iden3/circom", package = "dag" }
 circom-parser = { git = "https://github.com/iden3/circom", package = "parser" }
 circom-program_structure = { git = "https://github.com/iden3/circom", package = "program_structure" }
 circom-type_analysis = { git = "https://github.com/iden3/circom", package = "type_analysis" }
-
-# MPZ
-mpz-circuits = { git = "https://github.com/privacy-scaling-explorations/mpz", package = "mpz-circuits" }
-bmr16-mpz = { git = "https://github.com/tkmct/mpz", package = "mpz-circuits" }
-sim-circuit = { git = "https://github.com/brech1/sim-circuit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.196", features = ["derive"] }
 thiserror = "1.0.59"
 strum_macros = "0.26.4"
 strum = "0.26.2"
-sim-circuit = { git = "https://github.com/brech1/sim-circuit", branch = "feat/generic-circuit" }
+sim-circuit = { git = "https://github.com/brech1/sim-circuit" }
 
 # DSL
 circom-circom_algebra = { git = "https://github.com/iden3/circom", package = "circom_algebra" }

--- a/src/process.rs
+++ b/src/process.rs
@@ -760,6 +760,7 @@ fn to_equivalent_infix(op: &ExpressionPrefixOpcode) -> (u32, ExpressionInfixOpco
         ExpressionPrefixOpcode::Complement => (u32::MAX, ExpressionInfixOpcode::BitXor),
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,7 +2,8 @@
 //!
 //! Handles execution of statements and expressions for arithmetic circuit generation within a `Runtime` environment.
 
-use crate::compiler::{AGateType, Compiler};
+use crate::arithmetic_circuit::AGateType;
+use crate::compiler::Compiler;
 use crate::program::ProgramError;
 use crate::runtime::{
     generate_u32, increment_indices, u32_to_access, Context, DataAccess, DataType, NestedValue,


### PR DESCRIPTION
# Description

This PR updates the circuit evaluation to use the new `sim-circuit` structure.

We can now just use that as a library and define the execution for each type and each gate on our own crate.